### PR TITLE
LowSurfaceBrightness: remove hard-coded plate scale

### DIFF
--- a/SourceDetection/LowSurfaceBrightness.ipynb
+++ b/SourceDetection/LowSurfaceBrightness.ipynb
@@ -354,7 +354,8 @@
     "\n",
     "psf = calexp.getPsf()\n",
     "sigma = psf.computeShape().getDeterminantRadius()\n",
-    "print('psf fwhm = {:.2f} arcsec'.format(sigma*0.168*2.355))"
+    "pixelScale = calexp.getWcs().getPixelScale().asArcseconds()\n",
+    "print('psf fwhm = {:.2f} arcsec'.format(sigma*pixelScale*2.355))"
    ]
   },
   {


### PR DESCRIPTION
The plate scale is appropriate for HSC. Use the WCS instead of hard-coding.