### PR TITLE
Add the DM demo notebook "with-globular"

### DIFF
--- a/Visualization/README.md
+++ b/Visualization/README.md
@@ -5,3 +5,5 @@ This folder contains:
 * Nothing, yet.
 
 However, you can find the SQuaRE team's Firefly tutorial notebook [here](https://github.com/lsst-sqre/notebook-demo/blob/master/Firefly.ipynb), and watch the Phase 1 Session 1 video (in which Alex walks us through it) [here](https://www.youtube.com/watch?v=UjB0aaNd0MA).
+
+Another helpful notebook including image visualization with Firefly is Jim Bosch's [LSST2018 version](https://github.com/lsst-dm/dm-demo-notebooks/blob/master/workshops/lsst2018/intro-with-globular.ipynb) of the `with-globular` notebook.


### PR DESCRIPTION
Add a link to the with-globular notebook that has been updated for LSST 2018.