### PR TITLE
Cleanup cutouts syntax on calexp guided tour

### DIFF
--- a/Basics/Calexp_guided_tour.ipynb
+++ b/Basics/Calexp_guided_tour.ipynb
@@ -460,7 +460,7 @@
     "bbox = afwGeom.Box2I()\n",
     "bbox.include(afwGeom.Point2I(2200,3200))\n",
     "bbox.include(afwGeom.Point2I(2800,3800))\n",
-    "cutout = calexp.Factory(calexp, bbox, afwImage.LOCAL)"
+    "cutout = calexp[bbox]"
    ]
   },
   {
@@ -510,7 +510,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cutout_calexp = butler.get('calexp_sub', bbox=bbox, immediate=True, dataId=dataId)\n",
+    "cutout_calexp = butler.get('calexp_sub', bbox=bbox, dataId=dataId)\n",
     "cutout_calexp.getDimensions()"
    ]
   },
@@ -654,7 +654,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result of the `set` command above shows that a calexp and a coadd have the same methods."
+    "The result of the `set` command above shows that a calexp and a coadd have the same methods. This is expected, because they are the same class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(calexp.__class__, coadd.__class__)"
    ]
   },
   {


### PR DESCRIPTION
Respond to the very helpful comments on #57 made by @PaulPrice after the PR was merged.

* Use cleaner syntax for making cutouts
* Note that the coadd and the calexp are the same class, so they should all share the same methods.