### PR TITLE
`Taster` class for packaged-up data repo exploration 

### DIFF
--- a/Basics/DataInventory.ipynb
+++ b/Basics/DataInventory.ipynb
@@ -91,8 +91,15 @@
     "import numpy as np\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
-    "from IPython.display import IFrame, display, Markdown\n",
-    "\n",
+    "from IPython.display import IFrame, display, Markdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import stackclub"
    ]
   },
@@ -205,6 +212,80 @@
     "#     du -h $dataset\n",
     "# done"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exploring the Data Repo with the Stack Club `Taster`\n",
+    "\n",
+    "The `stackclub` library provides a `Taster` class, to explore the datasets in a given repo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "depth = 'WIDE' # WIDE, DEEP, UDEEP\n",
+    "field = 'SSP_WIDE' # SSP_WIDE, SSP_DEEP, SSP_UDEEP\n",
+    "repo = '/datasets/hsc/repo/rerun/DM-13666/%s/'%(depth)\n",
+    "\n",
+    "butler = dafPersist.Butler(repo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tarquin = stackclub.Taster(butler)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tarquin.look_for_dataset_of_type('calexp')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "help(tarquin)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# help(butler)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "butler.getMapperClass(repo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",

--- a/Basics/DataInventory.ipynb
+++ b/Basics/DataInventory.ipynb
@@ -382,25 +382,39 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "The following loops over all shared datasets fails in interesting ways: some folders don't seem to be `Butler`-friendly. We need to do a bit more work to identify the actual repos available to us."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "for repo in shared_datasets:\n",
+    "    try:\n",
+    "        taster = stackclub.Taster(repo)\n",
+    "        taster.report()\n",
+    "    except:\n",
+    "        print(\"Taster failed to explore repo \",repo)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "for repo in datasets:\n",
+    "    try:\n",
+    "        taster = stackclub.Taster(repo)\n",
+    "        taster.report()\n",
+    "    except:\n",
+    "        print(\"Taster failed to explore repo \",repo)"
+   ]
   },
   {
    "cell_type": "code",

--- a/Basics/DataInventory.ipynb
+++ b/Basics/DataInventory.ipynb
@@ -104,25 +104,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import lsst.daf.persistence as dafPersist\n",
-    "import lsst.daf.base as dafBase\n",
-    "\n",
-    "import lsst.afw.math as afwMath\n",
-    "import lsst.afw.geom as afwGeom\n",
-    "\n",
-    "import lsst.afw.detection as afwDetect\n",
-    "import lsst.afw.image as afwImage\n",
-    "import lsst.afw.table as afwTable\n",
-    "\n",
-    "import lsst.afw.display as afwDisplay"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -230,9 +211,130 @@
    "source": [
     "depth = 'WIDE' # WIDE, DEEP, UDEEP\n",
     "field = 'SSP_WIDE' # SSP_WIDE, SSP_DEEP, SSP_UDEEP\n",
-    "repo = '/datasets/hsc/repo/rerun/DM-13666/%s/'%(depth)\n",
+    "repo = '/datasets/hsc/repo/rerun/DM-13666/%s/'%(depth)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tarquin = stackclub.Taster(repo, vb=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The taster, `tarquin`, carries a butler around with it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(tarquin.butler)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It uses this butler to search the repo for datasets, skymaps etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tarquin.look_for_datasets_of_type(['raw', 'calexp', 'deepCoadd_calexp', 'deepCoadd_mergeDet'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tarquin.look_for_skymap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `what_exists` method searches for everything \"interesting\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tarquin.what_exists()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This dictionary is stored in the `exists` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tarquin.exists"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `Taster` can report on the data available, counting the number of visits, sources, etc, according to what's in the repo. It uses methods like this one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tarquin.estimate_sky_area()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and this one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tarquin.count_things()\n",
     "\n",
-    "butler = dafPersist.Butler(repo)"
+    "print(tarquin.counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To have your `Taster` do all the above, and just report on what it finds, do:"
    ]
   },
   {
@@ -241,7 +343,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tarquin = stackclub.Taster(butler)"
+    "tarquin.report()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For more on the `Taster`'s methods, do:"
    ]
   },
   {
@@ -250,7 +359,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tarquin.look_for_dataset_of_type('calexp')"
+    "# help(tarquin)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example Tastings"
    ]
   },
   {
@@ -259,7 +375,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "help(tarquin)"
+    "for depth in ['WIDE', 'DEEP', 'UDEEP']:\n",
+    "    repo = '/datasets/hsc/repo/rerun/DM-13666/%s/'%(depth)\n",
+    "    taster = stackclub.Taster(repo)\n",
+    "    taster.report()"
    ]
   },
   {
@@ -267,18 +386,28 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# help(butler)"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "butler.getMapperClass(repo)"
-   ]
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/Basics/DataInventory.ipynb
+++ b/Basics/DataInventory.ipynb
@@ -9,8 +9,8 @@
    },
    "source": [
     "# Exploring the Shared Datasets in the LSST Science Platform\n",
-    "<br>Owner(s): **Phil Marshall** ([@drphilmarshall](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall)), \n",
-    "<br>Last Verified to Run: **2018-08-05**\n",
+    "<br>Owner(s): **Phil Marshall** ([@drphilmarshall](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall)), **Rob Morgan** ([@rmorgan10](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@rmorgan10))\n",
+    "<br>Last Verified to Run: **2018-11-13**\n",
     "<br>Verified Stack Release: **16.0**\n",
     "\n",
     "In this notebook we'll take a look at some of the datasets available on the LSST Science Platform. \n",
@@ -20,9 +20,9 @@
     "After working through this tutorial you should be able to: \n",
     "1. Start figuring out which of the available datasets is going to be of most use to you in any given project; \n",
     "\n",
-    "When it is finished, you should be able to use the `stackclub` library function to:\n",
-    "2. Plot the patches and tracts in a given dataset on the sky;\n",
-    "3. List the available catalogs in a given dataset.\n",
+    "When it is finished, you should be able to use the `stackclub.Taster` to:\n",
+    "2. Report on the available data in a given dataset;\n",
+    "3. Plot the patches and tracts in a given dataset on the sky.\n",
     "\n",
     "### Logistics\n",
     "This notebook is intended to be runnable on `lsst-lspdev.ncsa.illinois.edu` from a local git clone of https://github.com/LSSTScienceCollaborations/StackClub.\n",
@@ -370,6 +370,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's compare the WIDE, DEEP and UDEEP parts of the HSC dataset."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -385,6 +392,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Hmm. The sky area is different but the `calexp` and `src` data is the same? Weird.\n",
+    "\n",
     "The following loops over all shared datasets fails in interesting ways: some folders don't seem to be `Butler`-friendly. We need to do a bit more work to identify the actual repos available to us."
    ]
   },

--- a/stackclub/__init__.py
+++ b/stackclub/__init__.py
@@ -1,3 +1,4 @@
 from .where_is import *
 from .wimport import *
 from .nbimport import *
+from .taster import *

--- a/stackclub/taster.py
+++ b/stackclub/taster.py
@@ -1,0 +1,28 @@
+class Taster(object):
+    """
+    Worker for tasting all the datasets in a Butler's repo.
+    Instantiate with a Butler object.
+    """
+    def __init__(self, butler):
+        self.butler = butler
+        
+        return
+    
+    def look_for_dataset_of_type(self, datasettype):
+        """
+        Check for the existence of the dataset of given type.
+        
+        Parameters
+        ==========
+        datasettype: string
+            Type of dataset to check for, eg 'calexp', 'raw', 'wcs' etc. 
+        """        
+        try:
+            datasetkeys = self.butler.getKeys(datasettype)
+            onekey = list(datasetkeys.keys())[0]
+            metadata = self.butler.queryMetadata(datasettype, [onekey])
+            print("{} dataset exists.".format(datasettype))
+            return True
+        except:
+            print("{} dataset doesn't exist.".format(datasettype))
+            return False

--- a/stackclub/taster.py
+++ b/stackclub/taster.py
@@ -77,6 +77,10 @@ class Taster(object):
         """
         if self.skyMap is None: return None
         
+        area_label = 'Total Sky Area (deg$^2$)'
+        if area_label in self.counts.keys():
+            return self.counts[area_label]
+        
         # Collect tracts from files
         import os, glob
         tracts = sorted([int(os.path.basename(x)) for x in
@@ -105,11 +109,11 @@ class Taster(object):
             # Combine areas
             total_area += area
 
-        if self.vb: print("Total area imaged (sq deg): ",total_area)
+        if self.vb: print(area_label, ": ", total_area)
 
         # Round of the total area for table purposes
-        self.counts['Total Sky Area (deg$^2$)'] = round(total_area, 2)
-        return self.counts['Total Sky Area (deg$^2$)']
+        self.counts[area_label] = round(total_area, 2)
+        return self.counts[area_label]
 
     def count_things(self):
         """
@@ -140,10 +144,11 @@ class Taster(object):
         # First check what's there:
         if not self.existence: self.what_exists()
         
-        # Then, count the things:
+        # Then, get the numbers:
         self.count_things()
+        self.estimate_sky_area()
         
-        # A more automated version of the table title:
+        # A nice bold section heading:
         display(Markdown('### %s' % self.repo))
 
         # Make a table of the collected metadata
@@ -151,6 +156,7 @@ class Taster(object):
         for key in self.counts.keys():
             output_table += "| %s |  %s | \n" %(key, self.counts[key])
         
+        # Display it:
         display(Markdown(output_table))
 
         return

--- a/stackclub/taster.py
+++ b/stackclub/taster.py
@@ -1,28 +1,156 @@
+import numpy as np
+from IPython.display import display, Markdown
+
 class Taster(object):
     """
     Worker for tasting all the datasets in a Butler's repo.
-    Instantiate with a Butler object.
+    Instantiate with a repo.
     """
-    def __init__(self, butler):
-        self.butler = butler
-        
+    def __init__(self, repo, vb=False):
+        self.repo = repo
+        from lsst.daf.persistence import Butler
+        self.butler = Butler(repo)
+        self.vb = vb
+        self.exists = {}
+        self.existence = False
+        self.counts = {}
         return
     
-    def look_for_dataset_of_type(self, datasettype):
+    def what_exists(self):
+        """
+        Check for the existence of various useful things. 
+        
+        Returns
+        =======
+        exists: dict
+            Checklist of what exists (True) and what does not (False)
+        """
+        interesting = ['raw', 'calexp', 'src', 'deepCoadd_calexp', 'deepCoadd_mergeDet']
+        self.look_for_datasets_of_type(interesting)
+        self.look_for_skymap()
+        self.existence = True
+        return self.exists
+    
+    def look_for_datasets_of_type(self, datasettypes):
         """
         Check for the existence of the dataset of given type.
         
         Parameters
         ==========
-        datasettype: string
-            Type of dataset to check for, eg 'calexp', 'raw', 'wcs' etc. 
-        """        
+        datasettype: list of strings
+            Types of dataset to check for, eg 'calexp', 'raw', 'wcs' etc. 
+        """
+        for datasettype in datasettypes:        
+            try:
+                datasetkeys = self.butler.getKeys(datasettype)
+                onekey = list(datasetkeys.keys())[0]
+                metadata = self.butler.queryMetadata(datasettype, [onekey])
+                if self.vb: print("{} dataset exists.".format(datasettype))
+                self.exists[datasettype] = True
+            except:
+                if self.vb: print("{} dataset doesn't exist.".format(datasettype))
+                self.exists[datasettype] = False
+        return
+    
+    def look_for_skymap(self):
+        """
+        Check for the existence of a skymap. 
+        """
         try:
-            datasetkeys = self.butler.getKeys(datasettype)
-            onekey = list(datasetkeys.keys())[0]
-            metadata = self.butler.queryMetadata(datasettype, [onekey])
-            print("{} dataset exists.".format(datasettype))
-            return True
+            self.skyMap = self.butler.get('deepCoadd_skyMap')
+            self.exists['deepCoadd_skyMap'] = True
+            if self.vb: print("deepCoadd_skyMap exists.")
         except:
-            print("{} dataset doesn't exist.".format(datasettype))
-            return False
+            self.skyMap = None
+            self.exists['deepCoadd_skyMap'] = False
+            if self.vb: print("deepCoadd_skyMap doesn't exist.")
+        return
+    
+    def estimate_sky_area(self):
+        """
+        Use available skymap to estimate sky area covered by tracts and patches.
+        
+        Returns
+        =======
+        area: float
+            Sky area in square degrees
+        """
+        if self.skyMap is None: return None
+        
+        # Collect tracts from files
+        import os, glob
+        tracts = sorted([int(os.path.basename(x)) for x in
+                 glob.glob(os.path.join(self.repo, 'deepCoadd-results', 'merged', '*'))])
+        self.counts['Number of Tracts'] = len(tracts)
+        # Note: We'd like to do this with the butler, but it appears 'tracts' have to be
+        #       specified in the dataId to be queried, so the queryMetadata method fails
+
+        # Calculate area from all tracts
+        total_area = 0.0  #deg^2
+        plotting_vertices = []
+        for test_tract in tracts:
+            # Get inner vertices for tract
+            tractInfo = self.skyMap[test_tract]
+            vertices = tractInfo._vertexCoordList
+            plotting_vertices.append(vertices)
+
+            # Calculate area of box
+            av_dec = 0.5 * (vertices[2][1] + vertices[0][1])
+            av_dec = av_dec.asRadians()
+            delta_ra_raw = vertices[0][0] - vertices[1][0] 
+            delta_ra = delta_ra_raw.asDegrees() * np.cos(av_dec)
+            delta_dec= vertices[2][1] - vertices[0][1]
+            area = delta_ra * delta_dec.asDegrees()
+
+            # Combine areas
+            total_area += area
+
+        if self.vb: print("Total area imaged (sq deg): ",total_area)
+
+        # Round of the total area for table purposes
+        self.counts['Total Sky Area (deg$^2$)'] = round(total_area, 2)
+        return self.counts['Total Sky Area (deg$^2$)']
+
+    def count_things(self):
+        """
+        Count the available number of visits, sensors, fields etc.
+        """
+        # Collect numbers of images of various kinds:
+        if self.exists['calexp']:
+            self.counts['Number of Visits'] = \
+                len(self.butler.queryMetadata('calexp', ['visit']))
+            self.counts['Number of Pointings'] = \
+                len(self.butler.queryMetadata('calexp', ['pointing']))
+            self.counts['Number of Sensor Visits'] = \
+                len(self.butler.queryMetadata('calexp', ['ccd']))
+            self.counts['Number of Fields'] = \
+                len(self.butler.queryMetadata('calexp', ['field']))
+            self.counts['Number of Filters'] = \
+                len(self.butler.queryMetadata('calexp', ['filter']))
+        # Collect number of objects from Source Catalog
+        if self.exists['src']:
+            self.counts['Number of Sources'] = \
+                len(self.butler.queryMetadata('src', ['id']))
+        return
+    
+    def report(self):
+        """
+        Print a nice report of the data available in this repo.
+        """
+        # First check what's there:
+        if not self.existence: self.what_exists()
+        
+        # Then, count the things:
+        self.count_things()
+        
+        # A more automated version of the table title:
+        display(Markdown('### %s' % self.repo))
+
+        # Make a table of the collected metadata
+        output_table = "|   Metadata Characteristics  |  | \n  | :---: | --- | \n "
+        for key in self.counts.keys():
+            output_table += "| %s |  %s | \n" %(key, self.counts[key])
+        
+        display(Markdown(output_table))
+
+        return


### PR DESCRIPTION
@rmorgan10 I had a go at transferring the data repo exploration code from our notebook into a `Taster` worker class: I'm using the Data Inventory notebook to demo it. See what you think - next job could be to make a skymap plot, I think. 

BTW, I suspect a bug but can't see what I've done wrong: the HSC dataset should have different datasets in the WIDE, DEEP and UDEEP repos, right? Right now I see this:

![image](https://user-images.githubusercontent.com/710903/48452675-fe0fe300-e764-11e8-9eba-9f2a0604044d.png)
