### PR TITLE
Stack Club notebooks on RTD

### DIFF
--- a/Basics/README.rst
+++ b/Basics/README.rst
@@ -1,7 +1,7 @@
 Basics
 ------
 
-This folder contains a set of tutorial notebooks exploring the basic properties of the DM Stack data structures, classes and functions. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
+This set of tutorial notebooks will help you explore the basic properties of the LSST software Stack data structures, classes and functions. The table contains links to the notebook code, and also to auto-rendered views of the notebooks with their outputs.
 
 
 .. list-table::

--- a/Basics/README.rst
+++ b/Basics/README.rst
@@ -14,7 +14,7 @@ This folder contains a set of tutorial notebooks exploring the basic properties 
      - Owner
 
 
-   * - **Calexp_guided_tour.ipynb**
+   * - **Calexp Guided Tour**
      - Shows how to read an exposure object from a data repository, and how to access and display various parts.
      - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/Calexp_guided_tour.ipynb>`__,
        `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/Calexp_guided_tour.nbconvert.ipynb>`__

--- a/Basics/README.rst
+++ b/Basics/README.rst
@@ -16,14 +16,14 @@ This folder contains a set of tutorial notebooks exploring the basic properties 
 
    * - **Calexp_guided_tour.ipynb**
      - Shows how to read an exposure object from a data repository, and how to access and display various parts.
-     - `ipynb <Calexp_guided_tour.ipynb>`__,
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/Calexp_guided_tour.ipynb>`__,
        `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/Calexp_guided_tour.nbconvert.ipynb>`__
 
        .. raw:: html
 
           <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/Calexp_guided_tour.log">
-            <object data="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Basics/log/Calexp_guided_tour.png">
-            </object>
+            <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Basics/log/Calexp_guided_tour.png">
+            </img>
           </a>
 
      - `David Shupe <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@stargaser>`_
@@ -31,13 +31,13 @@ This folder contains a set of tutorial notebooks exploring the basic properties 
 
    * - **Data Inventory**
      - Explore the available datasets in the LSST Science Platform shared folders.
-     - `ipynb <DataInventory.ipynb>`__,
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/DataInventory.ipynb>`__,
        `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/DataInventory.nbconvert.ipynb>`__
 
        .. raw:: html
 
           <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/DataInventory.log">
-             <img src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Basics/log/DataInventory.png">
+             <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Basics/log/DataInventory.png">
              </img>
           </a>
 

--- a/Basics/README.rst
+++ b/Basics/README.rst
@@ -1,8 +1,8 @@
 Basics
-======
+------
 
 This folder contains a set of tutorial notebooks exploring the basic properties of the DM Stack data structures, classes and functions. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
-    
+
 
 .. list-table::
    :widths: 10 20 10 10
@@ -16,21 +16,29 @@ This folder contains a set of tutorial notebooks exploring the basic properties 
 
    * - **Calexp_guided_tour.ipynb**
      - Shows how to read an exposure object from a data repository, and how to access and display various parts.
-     - `ipynb <Calexp_guided_tour.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/Calexp_guided_tour.nbconvert.ipynb>`_
+     - `ipynb <Calexp_guided_tour.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/Calexp_guided_tour.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/Calexp_guided_tour.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/Calexp_guided_tour.log
+       .. raw:: html
+
+          <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/Calexp_guided_tour.log">
+            <img src="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/Calexp_guided_tour.svg" type="image/svg+xml">
+            </img>
+          </a>
 
      - `David Shupe <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@stargaser>`_
 
 
    * - **Data Inventory**
      - Explore the available datasets in the LSST Science Platform shared folders.
-     - `ipynb <DataInventory.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/DataInventory.nbconvert.ipynb>`_
+     - `ipynb <DataInventory.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/DataInventory.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/DataInventory.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/DataInventory.log
+       .. raw:: html
+
+          <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/DataInventory.log">
+             <img src="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/DataInventory.svg" type="image/svg+xml">
+             </img>
+          </a>
 
      - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_

--- a/Basics/README.rst
+++ b/Basics/README.rst
@@ -22,8 +22,8 @@ This folder contains a set of tutorial notebooks exploring the basic properties 
        .. raw:: html
 
           <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/Calexp_guided_tour.log">
-            <img src="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/Calexp_guided_tour.svg" type="image/svg+xml">
-            </img>
+            <object data="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Basics/log/Calexp_guided_tour.png">
+            </object>
           </a>
 
      - `David Shupe <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@stargaser>`_
@@ -37,7 +37,7 @@ This folder contains a set of tutorial notebooks exploring the basic properties 
        .. raw:: html
 
           <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/DataInventory.log">
-             <img src="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Basics/log/DataInventory.svg" type="image/svg+xml">
+             <img src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Basics/log/DataInventory.png">
              </img>
           </a>
 

--- a/Calibration/README.rst
+++ b/Calibration/README.rst
@@ -1,8 +1,8 @@
 Calibration
-===========
+-----------
 
 This folder contains a set of tutorial notebooks exploring the calibration routines in the LSST science pipelines. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
-    
+
 
 .. list-table::
    :widths: 10 20 10 10

--- a/Deblending/README.rst
+++ b/Deblending/README.rst
@@ -1,5 +1,5 @@
 Deblending
-==========
+----------
 
 This folder contains a set of tutorial notebooks exploring the deblending of LSST objects. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
 

--- a/Deblending/README.rst
+++ b/Deblending/README.rst
@@ -16,21 +16,30 @@ This folder contains a set of tutorial notebooks exploring the deblending of LSS
 
    * - **SCARLET Tutorial**
      - Introduction to the SCARLET deblender, how to configure and run it.
-     - `ipynb <scarlet_tutorial.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/scarlet_tutorial.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Deblending/scarlet_tutorial.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/scarlet_tutorial.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/log/scarlet_tutorial.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/log/scarlet_tutorial.log
+       .. raw:: html
 
-     - `Fred Moolekamp <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@fred3m>`_
+             <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/log/scarlet_tutorial.log">
+               <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Deblending/log/scarlet_tutorial.png">
+               </img>
+             </a>
+
+     - `Fred Moolekamp <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@fred3m>`__
 
 
    * - **Deblending in DRP**
      - Where and how the deblending happens, in the DRP pipeline.
-     - `ipynb <lsst_stack_deblender.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/lsst_stack_deblender.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Deblending/lsst_stack_deblender.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/lsst_stack_deblender.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/log/lsst_stack_deblender.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/log/lsst_stack_deblender.log
+       .. raw:: html
 
-     - `Fred Moolekamp <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@fred3m>`_
+             <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Deblending/log/lsst_stack_deblender.log">
+               <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Deblending/log/lsst_stack_deblender.png">
+               </img>
+             </a>
+
+
+     - `Fred Moolekamp <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@fred3m>`__

--- a/GettingStarted/README.rst
+++ b/GettingStarted/README.rst
@@ -16,7 +16,7 @@ This folder contains notes on how to contribute Stack Club notebooks on the LSST
    * - **Notes on Getting Started**
      - Some brief notes on the LSST Science Platform JupyterLab set-up.
      - `markdown <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/GettingStarted/GettingStarted.md>`_
-     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_
+     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`__
 
 
    * - **Hello World**
@@ -37,7 +37,7 @@ This folder contains notes on how to contribute Stack Club notebooks on the LSST
    * - **Templates**
      - A folder containing a template notebook, and a template folder README file, to help you get your project started.
      - `link <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/GettingStarted/templates>`__
-     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_-
+     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`__
 
 
    * - **Finding Docs**
@@ -52,14 +52,14 @@ This folder contains notes on how to contribute Stack Club notebooks on the LSST
              </img>
           </a>
 
-     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_
+     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`__
 
 
 
    * - **Import Tricks**
      - Learn how to use some ``stackclub`` library utilities for importing notebooks and remote modules.
-     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/GettingStarted/ImportTricks.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/ImportTricks.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/GettingStarted/ImportTricks.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/ImportTricks.nbconvert.ipynb>`__
 
        .. raw:: html
 
@@ -69,4 +69,4 @@ This folder contains notes on how to contribute Stack Club notebooks on the LSST
           </a>
 
 
-     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_
+     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`__

--- a/GettingStarted/README.rst
+++ b/GettingStarted/README.rst
@@ -13,36 +13,44 @@ This folder contains notes on how to contribute Stack Club notebooks on the LSST
      - Owner
 
 
-   * - **GettingStarted.md**
+   * - **Notes on Getting Started**
      - Some brief notes on the LSST Science Platform JupyterLab set-up.
-     - `markdown <GettingStarted.md>`_
+     - `markdown <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/GettingStarted/GettingStarted.md>`_
      - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_
 
 
    * - **Hello World**
      - Read about the Stack Club git/GitHub workflow, and make your first contribution to a notebook.
-     - `ipynb <HelloWorld.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/HelloWorld.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/GettingStarted/HelloWorld.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/HelloWorld.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/HelloWorld.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/HelloWorld.log
+       .. raw:: html
 
-     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_
+          <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/HelloWorld.log">
+             <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/GettingStarted/log/HelloWorld.png">
+             </img>
+          </a>
+
+     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`__
 
 
-   * - **templates**
+   * - **Templates**
      - A folder containing a template notebook, and a template folder README file, to help you get your project started.
-     - `link <templates>`_
-     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_
+     - `link <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/GettingStarted/templates>`__
+     - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_-
 
 
    * - **Finding Docs**
      - Locate the documentation for Stack code objects, including using the ``stackclub`` library ``where_is`` utility function.
-     - `ipynb <FindingDocs.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/FindingDocs.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/GettingStarted/FindingDocs.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/FindingDocs.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/FindingDocs.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/FindingDocs.log
+       .. raw:: html
+
+          <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/FindingDocs.log">
+             <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/GettingStarted/log/FindingDocs.png">
+             </img>
+          </a>
 
      - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_
 
@@ -50,10 +58,15 @@ This folder contains notes on how to contribute Stack Club notebooks on the LSST
 
    * - **Import Tricks**
      - Learn how to use some ``stackclub`` library utilities for importing notebooks and remote modules.
-     - `ipynb <ImportTricks.ipynb>`_,
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/GettingStarted/ImportTricks.ipynb>`_,
        `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/ImportTricks.nbconvert.ipynb>`_
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/ImportTricks.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/ImportTricks.log
+       .. raw:: html
+
+          <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/ImportTricks.log">
+             <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/GettingStarted/log/ImportTricks.png">
+             </img>
+          </a>
+
 
      - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_

--- a/GettingStarted/README.rst
+++ b/GettingStarted/README.rst
@@ -1,8 +1,8 @@
 Getting Started
-===============
+---------------
 
 This folder contains notes on how to contribute Stack Club notebooks on the LSST Science Platform JupyterLab. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
- 
+
 .. list-table::
    :widths: 10 20 10 10
    :header-rows: 1
@@ -57,5 +57,3 @@ This folder contains notes on how to contribute Stack Club notebooks on the LSST
           :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/GettingStarted/log/ImportTricks.log
 
      - `Phil Marshall <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall>`_
-
-

--- a/GettingStarted/README.rst
+++ b/GettingStarted/README.rst
@@ -1,7 +1,7 @@
 Getting Started
 ---------------
 
-This folder contains notes on how to contribute Stack Club notebooks on the LSST Science Platform JupyterLab. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
+Wondering how you can get started learning about the LSST software stack, by writing tutorial notebooks and contributing them to the Stack Club's growing library? Need help getting going on the LSST Science Platform (LSP) JupyterLab? See the index table below for links to various resources, including: notes on the LSP, notebooks to walk you through the Stack Club workflow, and some help on how to explore the Stack code. Click on the "rendered" links to see the notebooks with their outputs.
 
 .. list-table::
    :widths: 10 20 10 10

--- a/GettingStarted/templates/template_README.rst
+++ b/GettingStarted/templates/template_README.rst
@@ -26,5 +26,4 @@ This folder contains a set of tutorial notebooks exploring <FOLDER_TOPICS>. See 
                </img>
              </a>
 
-
      - `TBD <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@TBD>`_

--- a/GettingStarted/templates/template_README.rst
+++ b/GettingStarted/templates/template_README.rst
@@ -2,7 +2,7 @@ FOLDER_NAME
 ===========
 
 This folder contains a set of tutorial notebooks exploring <FOLDER_TOPICS>. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
-    
+
 
 .. list-table::
    :widths: 10 20 10 10
@@ -16,10 +16,15 @@ This folder contains a set of tutorial notebooks exploring <FOLDER_TOPICS>. See 
 
    * - **None so far**
      - Not yet started.
-     - `ipynb <XXXX.ipynb>`_,
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/FOLDER_NAME/XXXX.ipynb>`_,
        `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/FOLDER_NAME/XXXX.nbconvert.ipynb>`_
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/FOLDER_NAME/log/XXXX.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/FOLDER_NAME/log/XXXX.log
+       .. raw:: html
+
+             <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/FOLDER_NAME/log/XXXX.log">
+               <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/FOLDER_NAME/log/XXXX.png">
+               </img>
+             </a>
+
 
      - `TBD <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@TBD>`_

--- a/GettingStarted/templates/template_README.rst
+++ b/GettingStarted/templates/template_README.rst
@@ -1,5 +1,5 @@
 FOLDER_NAME
-===========
+-----------
 
 This folder contains a set of tutorial notebooks exploring <FOLDER_TOPICS>. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
 
@@ -16,8 +16,8 @@ This folder contains a set of tutorial notebooks exploring <FOLDER_TOPICS>. See 
 
    * - **None so far**
      - Not yet started.
-     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/FOLDER_NAME/XXXX.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/FOLDER_NAME/XXXX.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/FOLDER_NAME/XXXX.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/FOLDER_NAME/XXXX.nbconvert.ipynb>`__
 
        .. raw:: html
 
@@ -26,4 +26,4 @@ This folder contains a set of tutorial notebooks exploring <FOLDER_TOPICS>. See 
                </img>
              </a>
 
-     - `TBD <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@TBD>`_
+     - `TBD <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@TBD>`__

--- a/ImageProcessing/README.rst
+++ b/ImageProcessing/README.rst
@@ -1,7 +1,7 @@
 Image Processing
 ----------------
 
-This folder contains a set of tutorial notebooks exploring the image processing routines in the LSST science pipelines. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
+Here, we explore the image processing routines in the LSST science pipelines. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
 
 
 .. list-table::
@@ -16,21 +16,29 @@ This folder contains a set of tutorial notebooks exploring the image processing 
 
    * - **Re-run HSC**
      - End-to-end processing of the ``ci_hsc`` test dataset using the DM Stack.
-     - `ipynb <Re-runHSC.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/Re-runHSC.nbconvert.ipynb>`_, `bash script <Re-runHSC.sh>`_,
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/ImageProcessing/Re-RunHSC.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/Re-RunHSC.nbconvert.ipynb>`_, `bash script <Re-RunHSC.sh>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/log/Re-runHSC.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/log/Re-runHSC.log
+       .. raw:: html
 
-     - `Justin Myles <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@jtmyles>`_
+             <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/log/Re-RunHSC.log">
+               <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/ImageProcessing/log/Re-RunHSC.png">
+               </img>
+             </a>
+
+     - `Justin Myles <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@jtmyles>`__
 
 
    * - **BrighterFatterCorrection.ipynb**
      - Analysis of Beam Simulator Images and Brighter-fatter Correction.
-     - `ipynb <BrighterFatterCorrection.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/BrighterFatterCorrection.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/ImageProcessing/BrighterFatterCorrection.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/BrighterFatterCorrection.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/log/BrighterFatterCorrection.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/log/BrighterFatterCorrection.log
+       .. raw:: html
 
-     - `Andrew Bradshaw <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@andrewkbradshaw>`_
+             <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/log/BrighterFatterCorrection.log">
+               <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/ImageProcessing/log/BrighterFatterCorrection.png">
+               </img>
+             </a>
+
+     - `Andrew Bradshaw <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@andrewkbradshaw>`__

--- a/ImageProcessing/README.rst
+++ b/ImageProcessing/README.rst
@@ -1,5 +1,5 @@
 Image Processing
-================
+----------------
 
 This folder contains a set of tutorial notebooks exploring the image processing routines in the LSST science pipelines. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
 
@@ -26,7 +26,7 @@ This folder contains a set of tutorial notebooks exploring the image processing 
 
 
    * - **BrighterFatterCorrection.ipynb**
-     - Analysis of Beam Simulator Images and Brighter-fatter Correction. 
+     - Analysis of Beam Simulator Images and Brighter-fatter Correction.
      - `ipynb <BrighterFatterCorrection.ipynb>`_,
        `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/BrighterFatterCorrection.nbconvert.ipynb>`_
 
@@ -34,4 +34,3 @@ This folder contains a set of tutorial notebooks exploring the image processing 
           :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/ImageProcessing/log/BrighterFatterCorrection.log
 
      - `Andrew Bradshaw <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@andrewkbradshaw>`_
-

--- a/Measurement/README.rst
+++ b/Measurement/README.rst
@@ -1,5 +1,5 @@
 Measurement
-===========
+-----------
 
 This folder contains a set of tutorial notebooks exploring the Object measurement routines in the LSST science pipelines. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
 

--- a/SourceDetection/README.rst
+++ b/SourceDetection/README.rst
@@ -1,7 +1,7 @@
 Source Detection
 ----------------
 
-This folder contains a set of tutorial notebooks exploring the source detection routines in the LSST science pipelines. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
+While source detection in the LSST science pipelines is carried out (first) during the image processing step, there are subsequent detection phases - and, moreover, we are interested in how sources are detected (and how their measured properties depends on that process). See the index table below for links to tutorial notebooks exploring this.
 
 
 .. list-table::
@@ -16,10 +16,14 @@ This folder contains a set of tutorial notebooks exploring the source detection 
 
    * - **LowSurfaceBrightness.ipynb**
      - Run source detection, deblending, and measurement tasks; subtract bright sources from an image; convolve image and detect low-surface brightness sources.
-     - `ipynb <LowSurfaceBrightness.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/SourceDetection/LowSurfaceBrightness.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/SourceDetection/log/LowSurfaceBrightness.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/SourceDetection/LowSurfaceBrightness.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/SourceDetection/log/LowSurfaceBrightness.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/SourceDetection/log/LowSurfaceBrightness.log
+       .. raw:: html
 
-     - `Alex Drlica-Wagner <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@kadrlica>`_
+             <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/SourceDetection/log/LowSurfaceBrightness.log">
+               <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/SourceDetection/log/LowSurfaceBrightness.png">
+               </img>
+             </a>
+
+     - `Alex Drlica-Wagner <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@kadrlica>`__

--- a/SourceDetection/README.rst
+++ b/SourceDetection/README.rst
@@ -1,8 +1,8 @@
 Source Detection
-================
+----------------
 
 This folder contains a set of tutorial notebooks exploring the source detection routines in the LSST science pipelines. See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
-    
+
 
 .. list-table::
    :widths: 10 20 10 10
@@ -23,4 +23,3 @@ This folder contains a set of tutorial notebooks exploring the source detection 
           :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/SourceDetection/log/LowSurfaceBrightness.log
 
      - `Alex Drlica-Wagner <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@kadrlica>`_
-

--- a/Validation/README.rst
+++ b/Validation/README.rst
@@ -1,9 +1,8 @@
 Validation
 ----------
 
-This folder contains a set of tutorial notebooks exploring the validation packages accompanying the DM Stack
-as well as stand-alone notebooks to examine various aspects of data quality.
-See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
+This set of tutorial notebooks explores the validation packages accompanying the LSST software Stack, and also contains some
+stand-alone notebooks useful for examining various aspects of data quality.
 
 .. list-table::
    :widths: 10 20 10 10
@@ -17,10 +16,14 @@ See the index table below for links to the notebook code, and an auto-rendered v
 
    * - **image_quality_demo.ipynb**
      - Examples of image shape measurements in the Stack including PSF size and ellipticity, shape measurements with and without PSF corrections; visualizing image quality statistics aggregated with pandas; examining PSF model ellipticity residuals
-     - `ipynb <image_quality_demo.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Validation/image_quality_demo.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Validation/image_quality_demo.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Validation/image_quality_demo.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Validation/log/image_quality_demo.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Validation/log/image_quality_demo.log
+       .. raw:: html
 
-     - `Keith Bechtol <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@bechtol>`_
+             <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Validation/log/image_quality_demo.log">
+               <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Validation/log/image_quality_demo.png">
+               </img>
+             </a>
+
+     - `Keith Bechtol <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@bechtol>`__

--- a/Validation/README.rst
+++ b/Validation/README.rst
@@ -1,5 +1,5 @@
 Validation
-==========
+----------
 
 This folder contains a set of tutorial notebooks exploring the validation packages accompanying the DM Stack
 as well as stand-alone notebooks to examine various aspects of data quality.
@@ -16,7 +16,7 @@ See the index table below for links to the notebook code, and an auto-rendered v
 
 
    * - **image_quality_demo.ipynb**
-     - Examples of image shape measurements in the Stack including PSF size and ellipticity, shape measurements with and without PSF corrections; visualizing image quality statistics aggregated with pandas; examining PSF model ellipticity residuals 
+     - Examples of image shape measurements in the Stack including PSF size and ellipticity, shape measurements with and without PSF corrections; visualizing image quality statistics aggregated with pandas; examining PSF model ellipticity residuals
      - `ipynb <image_quality_demo.ipynb>`_,
        `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Validation/image_quality_demo.nbconvert.ipynb>`_
 

--- a/Visualization/README.rst
+++ b/Visualization/README.rst
@@ -1,5 +1,5 @@
 Visualization
-=============
+-------------
 
 This folder contains a set of tutorial notebooks demonstrating visualization technologies available in the LSST Science Platform notebook aspect.
 See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.

--- a/Visualization/README.rst
+++ b/Visualization/README.rst
@@ -1,8 +1,7 @@
 Visualization
 -------------
 
-This folder contains a set of tutorial notebooks demonstrating visualization technologies available in the LSST Science Platform notebook aspect.
-See the index table below for links to the notebook code, and an auto-rendered view of the notebook with outputs.
+See the table below for a set of tutorial notebooks (some provided by the Project) demonstrating visualization technologies available in the LSST Science Platform notebook aspect.
 
 .. list-table::
    :widths: 10 20 10 10
@@ -16,21 +15,25 @@ See the index table below for links to the notebook code, and an auto-rendered v
 
    * - **Firefly Visualization Demo**
      - Introduction to the Firefly interactive plotter and image viewer.
-     - `ipynb <https://github.com/lsst-sqre/notebook-demo/blob/master/Firefly.ipynb>`_, `video <https://www.youtube.com/watch?v=UjB0aaNd0MA>`_
-     - `Simon Krughoff <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@SimonKrughoff>`_
+     - `ipynb <https://github.com/lsst-sqre/notebook-demo/blob/master/Firefly.ipynb>`__, `video <https://www.youtube.com/watch?v=UjB0aaNd0MA>`__
+     - `Simon Krughoff <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@SimonKrughoff>`__
 
 
    * - **Interactive Visualization with Bokeh, HoloViews, and Datashader**
      - Examples of interactive visualization with the Boken, HoloViews, and Datashader plotting packages available in PyViz suite of data analysis python modules; brushing and linking with large datasets
-     - `ipynb <bokeh_holoviews_datashader.ipynb>`_,
-       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Visualization/bokeh_holoviews_datashader.nbconvert.ipynb>`_
+     - `ipynb <https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Visualization/bokeh_holoviews_datashader.ipynb>`__,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTScienceCollaborations/StackClub/blob/rendered/Visualization/bokeh_holoviews_datashader.nbconvert.ipynb>`__
 
-       .. image:: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Visualization/log/bokeh_holoviews_datashader.svg
-          :target: https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Visualization/log/bokeh_holoviews_datashader.log
+       .. raw:: html
 
-     - `Keith Bechtol <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@bechtol>`_
+             <a href="https://github.com/LSSTScienceCollaborations/StackClub/blob/rendered/Visualization/log/bokeh_holoviews_datashader.log">
+               <img width="72" height="16" src="https://raw.githubusercontent.com/LSSTScienceCollaborations/StackClub/rendered/Visualization/log/bokeh_holoviews_datashader.png">
+               </img>
+             </a>
+
+     - `Keith Bechtol <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@bechtol>`__
 
    * - **"With Globular" LSST 2018 Tutorial**
      - General purpose tutorial including interactive Firefly visualization.
-     - `ipynb <https://github.com/lsst-dm/dm-demo-notebooks/blob/master/workshops/lsst2018/intro-with-globular.ipynb>`_
-     - `Jim Bosch <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@TallJimbo>`_
+     - `ipynb <https://github.com/lsst-dm/dm-demo-notebooks/blob/master/workshops/lsst2018/intro-with-globular.ipynb>`__
+     - `Jim Bosch <https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@TallJimbo>`__

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,14 @@ napoleon_use_ivar = True
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
+html_static_path = ['_static']
+
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+        ],
+     }
+
 master_doc = 'index'
 autosummary_generate = True
 autoclass_content = "class"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,34 +1,11 @@
-The Stack Club Library
-======================
-The LSST science collaborations' `Stack Club <https://github.com/LSSTScienceCollaborations/StackClub/>`_ is learning the LSST software "stack" by writing tutorial Jupyter notebooks about it. These notebooks make use of a number of homegrown functions and classes, which are kept in the ``stackclub`` package for easy import. You can browse these modules below. 
+Stack Club
+==========
+The LSST science collaborations' `Stack Club <https://github.com/LSSTScienceCollaborations/StackClub/>`_ is learning the LSST software "stack" by writing tutorial Jupyter notebooks about it. These notebooks are organized by topic area, and can be browsed at the links below. There is also the ``stackclub`` library of useful python tools that you can import and use - click through below to learn more about them.
 
 Contents:
 
 .. toctree::
     :maxdepth: 2
-    
-    index
 
-
-Finding Documentation
----------------------
-
-.. automodule:: where_is
-    :members:
-    :undoc-members:
-
-Importing Modules from the Web
-------------------------------
-
-.. automodule:: wimport
-    :members:
-    :undoc-members:
-
-Importing Notebooks as Modules
-------------------------------
-
-Once this module has been imported, further ``import`` statements will treat Jupyter notebooks as importable modules. It's unlikely that you will need to call any of the functions or classes in :mod:`nbimport` yourself - this section is just for reference. 
-
-.. automodule:: nbimport
-    :members:
-    :undoc-members:
+    ../Basics/README
+    stackclub

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,9 @@
 Stack Club
 ==========
-The LSST science collaborations' `Stack Club <https://github.com/LSSTScienceCollaborations/StackClub/>`_ is learning the LSST software "stack" by writing tutorial Jupyter notebooks about it. These notebooks are organized by topic area, and can be browsed at the links below. There is also the ``stackclub`` library of useful python tools that you can import and use - click through below to learn more about them.
+The LSST science collaborations' `Stack Club <https://github.com/LSSTScienceCollaborations/StackClub/>`_ is learning the LSST software "stack" by writing tutorial Jupyter notebooks about it. These notebooks are organized by topic area, and can be browsed at the links below. There is also the ``stackclub`` package of useful python tools that you can import and use - click through below to learn more about them.
 
 .. toctree::
     :maxdepth: 2
 
     notebooks
-
     stackclub

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,10 +2,9 @@ Stack Club
 ==========
 The LSST science collaborations' `Stack Club <https://github.com/LSSTScienceCollaborations/StackClub/>`_ is learning the LSST software "stack" by writing tutorial Jupyter notebooks about it. These notebooks are organized by topic area, and can be browsed at the links below. There is also the ``stackclub`` library of useful python tools that you can import and use - click through below to learn more about them.
 
-Contents:
-
 .. toctree::
     :maxdepth: 2
 
-    ../Basics/README
+    notebooks
+
     stackclub

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -1,0 +1,10 @@
+Tutorial Notebooks
+==================
+
+.. include:: ../GettingStarted/README.rst
+.. include:: ../Basics/README.rst
+.. include:: ../Visualization/README.rst
+.. include:: ../ImageProcessing/README.rst
+.. include:: ../SourceDetection/README.rst
+.. include:: ../Deblending/README.rst
+.. include:: ../Validation/README.rst

--- a/docs/stackclub.rst
+++ b/docs/stackclub.rst
@@ -5,23 +5,26 @@ The Stack Club tutorial Jupyter notebooks make use of a number of homegrown func
 
 Finding Documentation
 ---------------------
+There are a number of good places to find information about the classes and functions in the LSST software Stack: the built-in Jupyter notebook ``help()`` function already gets us a long way, but if you want to locate and read the source code, the ``stackclub.where_is`` function can help.
 
 .. automodule:: where_is
     :members:
     :undoc-members:
 
-Importing Modules from the Web
-------------------------------
-
-.. automodule:: wimport
-    :members:
-    :undoc-members:
 
 Importing Notebooks as Modules
 ------------------------------
-
 Once this module has been imported, further ``import`` statements will treat Jupyter notebooks as importable modules. It's unlikely that you will need to call any of the functions or classes in :mod:`nbimport` yourself - this section is just for reference.
 
 .. automodule:: nbimport
+    :members:
+    :undoc-members:
+
+
+Importing Modules from the Web
+------------------------------
+This is pretty experimental!
+
+.. automodule:: wimport
     :members:
     :undoc-members:

--- a/docs/stackclub.rst
+++ b/docs/stackclub.rst
@@ -1,0 +1,34 @@
+The Stack Club Library
+======================
+The Stack Club tutorial Jupyter notebooks make use of a number of homegrown functions and classes, which are kept in the ``stackclub`` package for easy import. You can browse these modules below.
+
+Contents:
+
+.. toctree::
+    :maxdepth: 2
+
+    stackclub
+
+
+Finding Documentation
+---------------------
+
+.. automodule:: where_is
+    :members:
+    :undoc-members:
+
+Importing Modules from the Web
+------------------------------
+
+.. automodule:: wimport
+    :members:
+    :undoc-members:
+
+Importing Notebooks as Modules
+------------------------------
+
+Once this module has been imported, further ``import`` statements will treat Jupyter notebooks as importable modules. It's unlikely that you will need to call any of the functions or classes in :mod:`nbimport` yourself - this section is just for reference.
+
+.. automodule:: nbimport
+    :members:
+    :undoc-members:

--- a/docs/stackclub.rst
+++ b/docs/stackclub.rst
@@ -1,13 +1,6 @@
-The Stack Club Library
-======================
+The ``stackclub`` Package
+=========================
 The Stack Club tutorial Jupyter notebooks make use of a number of homegrown functions and classes, which are kept in the ``stackclub`` package for easy import. You can browse these modules below.
-
-Contents:
-
-.. toctree::
-    :maxdepth: 2
-
-    stackclub
 
 
 Finding Documentation


### PR DESCRIPTION
Just to get started, I re-made the docs/index.rst file as a global Stack Club home page, and moved the `stackclub` package API docs to a separate RST file. Next up I'll try to bring in the notebooks. This is not ready for review yet - but I'll keep you posted, and log my progress on issue #164 in this PR thread. 