### PR TITLE
Run deblending tutorial on current version of the stack

### DIFF
--- a/Deblending/lsst_stack_deblender.ipynb
+++ b/Deblending/lsst_stack_deblender.ipynb
@@ -349,7 +349,6 @@
     "# Because we're not running the plugin these slots refer to by default,\n",
     "# we need to disable them in the configuration.\n",
     "measureConfig.slots.apFlux = None\n",
-    "#measureConfig.slots.instFlux = None\n",
     "measureConfig.slots.shape = None\n",
     "measureConfig.slots.modelFlux = None\n",
     "measureConfig.slots.calibFlux = None\n",

--- a/Deblending/lsst_stack_deblender.ipynb
+++ b/Deblending/lsst_stack_deblender.ipynb
@@ -7,7 +7,7 @@
     "# Using the LSST Stack Multiband Deblender \n",
     "<br>Owner(s): **Fred Moolekamp** ([@fred3m](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@fred3m))\n",
     "<br>Last Verified to Run: **2018-08-17**\n",
-    "<br>Verified Stack Release: **w_2018_32**\n",
+    "<br>Verified Stack Release: **w_2019_06**\n",
     "\n",
     "This tutorial is designed to illustrate how to execute the multiband deblender (*scarlet*) in the LSST stack. This includes a brief introduction to LSST stack objects including:\n",
     "\n",

--- a/Deblending/lsst_stack_deblender.ipynb
+++ b/Deblending/lsst_stack_deblender.ipynb
@@ -54,6 +54,33 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lsst.afw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lsst.afw.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lsst.afw.image import MultibandExposure"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -322,10 +349,11 @@
     "# Because we're not running the plugin these slots refer to by default,\n",
     "# we need to disable them in the configuration.\n",
     "measureConfig.slots.apFlux = None\n",
-    "measureConfig.slots.instFlux = None\n",
+    "#measureConfig.slots.instFlux = None\n",
     "measureConfig.slots.shape = None\n",
     "measureConfig.slots.modelFlux = None\n",
     "measureConfig.slots.calibFlux = None\n",
+    "measureConfig.slots.gaussianFlux = None\n",
     "measureTask = SingleFrameMeasurementTask(config=measureConfig, schema=schema)"
    ]
   },
@@ -352,19 +380,19 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's take a quick look at what's in that catalog.  First off, we can look at its schema:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "catalog.schema"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a quick look at what's in that catalog.  First off, we can look at its schema:"
    ]
   },
   {
@@ -627,7 +655,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR addresses Issue #166 and includes minor modifications to `lsst_stack_deblender.ipynb` so that it runs with version `w_2019_06` of the stack. Changes were made in configuring the `SingleFrameMeasurementTask`, where the line `measureConfig.slots.instFlux = None` resulted in an attribute error:

```AttributeError: lsst.meas.base.baseMeasurement.SourceSlotConfig has no attribute instFlux```

and subsequently running `table = SourceCatalog.Table.make(schema)` resulted in:

```
NotFoundError: 
  File "src/table/Schema.cc", line 226, in lsst::afw::table::SchemaItem<T> lsst::afw::table::detail::SchemaImpl::find(const string&) const [with T = double; std::string = std::basic_string<char>]
    Field or subfield with name 'base_GaussianFlux_instFlux' not found with type 'D'. {0}
lsst::pex::exceptions::NotFoundError: 'Field or subfield with name 'base_GaussianFlux_instFlux' not found with type 'D'.
```
The notebook is now running without any issues, but I'm not sure whether my 'fix' is the correct way to proceed. If @fred3m or anyone else has any suggestions or comments it would be much appreciated!