### PR TITLE
Update Calexp Guided Tour and add VisitInfo

### DIFF
--- a/Basics/Calexp_guided_tour.ipynb
+++ b/Basics/Calexp_guided_tour.ipynb
@@ -581,7 +581,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's get the aperture correctin map and print some information about it"
+    "Let's get the aperture correction map and print some information about it"
    ]
   },
   {
@@ -999,13 +999,6 @@
     "display1.zoom(16)\n",
     "display1.pan(18700, 17000)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Basics/Calexp_guided_tour.ipynb
+++ b/Basics/Calexp_guided_tour.ipynb
@@ -2,19 +2,35 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "toc-hr-collapsed": false
+   },
    "source": [
     "# A Guided Tour of LSST Calexps\n",
     "<br>Owner(s): **David Shupe** ([@stargaser](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@stargaser))\n",
-    "<br>Last Verified to Run: **2018-08-07**\n",
+    "<br>Last Verified to Run: **2019-02-08**\n",
     "<br>Verified Stack Release: **v16.0** (also lsst_w_2018_31, with `getName` modification)\n",
     "\n",
-    "We'll inspect a visit image ``calexp`` object, and then show how a coadd image differs.\n",
-    "\n",
+    "We'll inspect a visit image ``calexp`` object, and then show how a coadd image differs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc-hr-collapsed": false
+   },
+   "source": [
     "### Learning Objectives:\n",
     "\n",
-    "After working through this tutorial you should be able to follow some best practices when working with LSST ``calexp`` (image) objects.\n",
-    "\n",
+    "After working through this tutorial you should be able to follow some best practices when working with LSST ``calexp`` (image) objects."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc-hr-collapsed": false
+   },
+   "source": [
     "### Logistics\n",
     "This notebook is intended to be runnable on `lsst-lsp-stable.ncsa.illinois.edu` from a local git clone of https://github.com/LSSTScienceCollaborations/StackClub.\n",
     "\n",
@@ -85,6 +101,13 @@
    "source": [
     "dataId = {'filter': 'r', 'raft': '2,2', 'sensor': '1,1', 'visit': 235}\n",
     "calexp = butler.get('calexp', **dataId)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Image planes / pixel data"
    ]
   },
   {
@@ -305,6 +328,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Access the wcs object"
    ]
   },
@@ -349,7 +379,7 @@
    "source": [
     "metadata = calexp.getMetadata()\n",
     "# help(metadata)\n",
-    "metadata.getOrderedNames()"
+    "print(metadata.getOrderedNames())"
    ]
   },
   {
@@ -366,6 +396,147 @@
    "metadata": {},
    "source": [
     "> Post release 16.0, the `getName` method will be available."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Better metadata: VisitInfo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calexp_info = calexp.getInfo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "visit_info = calexp_info.getVisitInfo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dir(visit_info)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "visit_info.getWeather()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "polygon = calexp_info.getValidPolygon()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calexp_info.hasValidPolygon()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calexp_info.hasApCorrMap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calexp_info.hasCoaddInputs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calexp_info.hasTransmissionCurve()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calexp_info.hasDetector()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calexp_info.hasWcs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dir(calexp_info.getDetector())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "apCorrMap = calexp_info.getApCorrMap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for k in apCorrMap.keys():\n",
+    "    print(k, apCorrMap.get(k))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Image PSF"
    ]
   },
   {
@@ -408,6 +579,24 @@
    "source": [
     "from lsst.geom.coordinates import Point2D\n",
     "psfimage = psf.computeImage(Point2D(100.,100.))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize the PSF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display1 = afw_display.Display(frame=1, backend='matplotlib')\n",
+    "display1.scale('asinh', min=0.0, max=1.e-3, unit='absolute')\n",
+    "display1.mtv(psfimage)"
    ]
   },
   {
@@ -477,7 +666,7 @@
    "outputs": [],
    "source": [
     "display1 = afw_display.Display(frame=1, backend='matplotlib')\n",
-    "display1.scale(\"asinh\", \"zscale\")\n",
+    "display1.scale('asinh', 'zscale')\n",
     "display1.mtv(cutout.image)"
    ]
   },
@@ -521,7 +710,7 @@
    "outputs": [],
    "source": [
     "display1 = afw_display.Display(frame=1, backend='matplotlib')\n",
-    "display1.scale(\"asinh\", \"zscale\")\n",
+    "display1.scale('asinh', 'zscale')\n",
     "display1.mtv(cutout_calexp.image)"
    ]
   },
@@ -554,7 +743,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "toc-hr-collapsed": false
+   },
    "source": [
     "## Repeat for a coadd"
    ]
@@ -737,6 +928,13 @@
     "display1.zoom(16)\n",
     "display1.pan(18700, 17000)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -755,7 +953,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/Basics/Calexp_guided_tour.ipynb
+++ b/Basics/Calexp_guided_tour.ipynb
@@ -43,6 +43,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pprint import pprint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from lsst.daf.persistence import Butler"
    ]
   },
@@ -378,8 +387,7 @@
    "outputs": [],
    "source": [
     "metadata = calexp.getMetadata()\n",
-    "# help(metadata)\n",
-    "print(metadata.getOrderedNames())"
+    "pprint(metadata.toDict())"
    ]
   },
   {
@@ -429,7 +437,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dir(visit_info)"
+    "[m for m in dir(visit_info) if not m.startswith('_')]"
    ]
   },
   {
@@ -550,7 +558,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dir(calexp_info.getDetector())"
+    "[m for m in dir(calexp_info.getDetector()) if not m.startswith('_')]"
    ]
   },
   {
@@ -640,8 +648,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lsst.geom import Point2D\n",
-    "psfimage = psf.computeImage(Point2D(100.,100.))"
+    "from lsst.geom import PointD\n",
+    "psfimage = psf.computeImage(PointD(100.,100.))"
    ]
   },
   {
@@ -675,7 +683,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calib = calexp.getCalib()\n",
+    "calib = calexp.getPhotoCalib()\n",
     "calib"
    ]
   },

--- a/Basics/Calexp_guided_tour.ipynb
+++ b/Basics/Calexp_guided_tour.ipynb
@@ -8,8 +8,8 @@
    "source": [
     "# A Guided Tour of LSST Calexps\n",
     "<br>Owner(s): **David Shupe** ([@stargaser](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@stargaser))\n",
-    "<br>Last Verified to Run: **2019-02-08**\n",
-    "<br>Verified Stack Release: **v16.0** (also lsst_w_2018_31, with `getName` modification)\n",
+    "<br>Last Verified to Run: **2019-08-13**\n",
+    "<br>Verified Stack Release: **v18.1.0**\n",
     "\n",
     "We'll inspect a visit image ``calexp`` object, and then show how a coadd image differs."
    ]
@@ -395,14 +395,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Post release 16.0, the `getName` method will be available."
+    "### Better metadata: ExposureInfo and VisitInfo"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Better metadata: VisitInfo"
+    "For many purposes, information about an exposure is obtainable via the ExposureInfo and VisitInfo classes."
    ]
   },
   {
@@ -433,6 +433,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Obtain weather information for this visit"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -442,12 +449,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "polygon = calexp_info.getValidPolygon()"
+    "Check if this calexp has a valid polygon"
    ]
   },
   {
@@ -460,12 +465,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since there is no valid polygon, the `polygon` variable in the next cell gets the value of None."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "calexp_info.hasApCorrMap()"
+    "polygon = calexp_info.getValidPolygon()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The calexp is not a coadd so this method returns False."
    ]
   },
   {
@@ -478,12 +497,42 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Does the calexp contain transmission curve information?"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "calexp_info.hasTransmissionCurve()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Does the calexp contain a World Coordinate System?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calexp_info.hasWcs()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Does the calexp have a detector?"
    ]
   },
   {
@@ -501,7 +550,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calexp_info.hasWcs()"
+    "dir(calexp_info.getDetector())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Does the calexp have an aperture correction map?"
    ]
   },
   {
@@ -510,7 +566,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dir(calexp_info.getDetector())"
+    "calexp_info.hasApCorrMap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's get the aperture correctin map and print some information about it"
    ]
   },
   {
@@ -577,7 +640,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lsst.geom.coordinates import Point2D\n",
+    "from lsst.geom import Point2D\n",
     "psfimage = psf.computeImage(Point2D(100.,100.))"
    ]
   },


### PR DESCRIPTION
This pull request updates the Calexp Guided Tour for v18.1.0. It includes some work-in-progress made over the past year, that I had not gotten around to making into a pull request.

* Update the import of `Point2D` which causes builds to fail
* Show how to use `afwDisplay` to display the PSF (a request from LSST PCW 2018)
* Include a new section on using `VisitInfo` and `ExposureInfo`

The new notebook runs for me on lsst-lsp-stable with v18.1.0.