### PR TITLE
v18 updates for introduction to afw table 

### DIFF
--- a/Basics/afw_table_guided_tour.ipynb
+++ b/Basics/afw_table_guided_tour.ipynb
@@ -1015,7 +1015,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "calexp_calib_twinkles = butler.get('calexp_calib', dataId)"
+    "calexp_calib_twinkles = butler.get('calexp_photoCalib', dataId)"
    ]
   },
   {
@@ -1031,8 +1031,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "src_tw_mags, src_tw_magErr = calexp_calib_twinkles.getMagnitude(src_twinkles['base_GaussianFlux_flux'],\n",
-    "                                   src_twinkles['base_GaussianFlux_fluxSigma'])"
+    "src_tw_mags = [calexp_calib_twinkles.instFluxToMagnitude(rec['base_GaussianFlux_flux']) for rec in src_twinkles]\n",
+    "src_tw_magErr = [ calexp_calib_twinkles.instFluxToMagnitude(rec['base_GaussianFlux_fluxSigma']) for rec in src_twinkles]"
    ]
   },
   {
@@ -1217,7 +1217,7 @@
     "    obj_id_1 = m.first.getId()\n",
     "    obj_id_2 = m.second.getId()\n",
     "    dist = m.distance* 360*60*60/ (2*np.pi)\n",
-    "    mag_resid = m.first['r_mag'] - calexp_calib_twinkles.getMagnitude(m.second['ext_photometryKron_KronFlux_flux'])\n",
+    "    mag_resid = m.first['r_mag'] - calexp_calib_twinkles.instFluxToMagnitude(m.second['ext_photometryKron_KronFlux_flux'])\n",
     "    print('id 1: {} id 2: {} distance {} mag {}'.format(obj_id_1, obj_id_2, dist, mag_resid))"
    ]
   },
@@ -1324,7 +1324,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.2"
   },
   "livereveal": {
    "scroll": true,

--- a/Basics/afw_table_guided_tour.ipynb
+++ b/Basics/afw_table_guided_tour.ipynb
@@ -10,8 +10,8 @@
    "source": [
     "# afwTables: A Guided Tour\n",
     "<br>Owner(s): **Imran Hasan** ([@ih64](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@ih64))\n",
-    "<br>Last Verified to Run: **2019-03-22**\n",
-    "<br>Verified Stack Release: **17.0.1**\n",
+    "<br>Last Verified to Run: **2019-08-13**\n",
+    "<br>Verified Stack Release: **18.1.0**\n",
     "\n",
     "Catalogs of astronomical objects and their many  measurements will be a primary data product that LSST provides. Queries of those catalogs will be the starting point for almost all LSST science analyses. On the way to filling the LSST database with these catalogs, the science pipelines will generate and manipulate a lot of internal tables; the python class that the Stack defines and uses for these tables is called an \"afwTable\". \n",
     "\n",


### PR DESCRIPTION
problems were: 

*have to use 'calexp_photoCalib' instead of 'calexp_calib' as the data product to retrieve to get magnitudes
*have to use `photoCalib`.instFluxToMagnitude' now instead of 'getMagnitude'
