### PR TITLE
Fixes incorrect object type name

### DIFF
--- a/Basics/ButlerTutorial.ipynb
+++ b/Basics/ButlerTutorial.ipynb
@@ -147,7 +147,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is important to note that if you specify a key that is not part of the data **type**, the butler will silently ignore it. This can be misleading. For example, specifying the key `merge_footprint_i` does not select the rows in the returned table where `merge_footprint_i` is the specified value. This is shown in the following example:\n"
+    "It is important to note that if you specify a key that is not part of the data **type**, the `Butler` will silently ignore it. This can be misleading. For example, in the previous example we read in a table that has a column of booleans named `merge_footprint_i`. If you specify `merge_footprint_i: True` in the dataID and rerun the example, `Butler` will ignore the extra key silently. As a result, you might expect the returned table to only include values where `merge_footprint_i` is `True`, but that isn't what happens. \n",
+    "\n",
+    "Here is an example of the correct way to select data from the returned table:\n"
    ]
   },
   {
@@ -156,11 +158,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Don't do this!\n",
+    "# An example of what not to do!!\n",
+    "#\n",
     "# new_data_id = {'tract': 0, 'patch': '1,1', 'merge_footprint_i': True}\n",
     "# merged_i_data = butler.get(dataset_type, dataId=new_data_id)\n",
+    "# assert merged_i_data['merge_measurement_i'].all()\n",
     "\n",
-    "# Do this...\n",
+    "# Do this instead...\n",
     "new_data_id = {'tract': 0, 'patch': '1,1'}\n",
     "merged_i_data = butler.get(dataset_type, dataId=new_data_id)\n",
     "merged_i_data = merged_i_data[merged_i_data['merge_measurement_i']].copy(True)\n",
@@ -232,6 +236,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we plot our cutout."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -255,7 +266,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since the postage stamp was generated using `Butler`, we can plot it using the DM `afwDisplay` module."
+    "Since the postage stamp was generated using `Butler`, it is represented as an `afwImage` object. This is a data type from the DM stack that is used to represent images. Since it is a DM object, we choose to plot it using the DM `afwDisplay` module."
    ]
   },
   {
@@ -281,7 +292,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is important to note that the cutout image is aware of what the pixel values were in the original image. This is why the axis labels in the above cutout are so large. We also note that the orientation of the postage stamp is in the x, y orientation of the original coadded image.\n"
+    "Note that the cutout image is aware of the masks and pixel values of the original image. This is why the axis labels in the above cutout are so large. We also note that the orientation of the postage stamp is in the x, y orientation of the original coadded image.\n"
    ]
   },
   {
@@ -290,7 +301,7 @@
    "source": [
     "## Selecting an Area on the Sky with a Sky Map\n",
     "\n",
-    "As a final example, we consider a third type of data that can be accessed via `Butler` called a `skyMap`. Sky maps allow you to look up information for a given `tract` and `patch`. You may notice from the below example that data set **types** tend to follow the convention of having a base name (e.g. `'deepCoadd'`) followed by a descriptor (e.g. `'_skyMap'`)."
+    "As a final example, we consider a third type of data that can be accessed via `Butler` called a `skyMap`. Sky maps allow you to look up information for a given `tract` and `patch`. You may notice from the below example that data set **types** tend to follow the naming convention of having a base name (e.g. `'deepCoadd'`) followed by a descriptor (e.g. `'_skyMap'`)."
    ]
   },
   {


### PR DESCRIPTION
Minor text clarifications to `Basics/ButlerTutorial.ipynb`. Includes a sight addition to the discussion on selecting subsets of data, and explicitly notes that cutout images are returned as `ExposureF` objects.