### PR TITLE
Updating stackclub doc finding

### DIFF
--- a/GettingStarted/FindingDocs.ipynb
+++ b/GettingStarted/FindingDocs.ipynb
@@ -7,20 +7,31 @@
     "# How to Find DM Stack Documentation\n",
     "\n",
     "<br>Owner(s): **Phil Marshall** ([@drphilmarshall](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall))\n",
-    "<br>Last Verified to Run: **2018-08-05**\n",
-    "<br>Verified Stack Release: **16.0**\n",
+    "<br>Last Verified to Run: **2020-07-13**\n",
+    "<br>Verified Stack Release: **20.0.0**\n",
     "\n",
     "### Learning Objectives:\n",
     "\n",
     "In this notebook we will look at a few different ways to find the documentation on a given DM Stack function or class. \n",
     "After working through this tutorial you should be able to: \n",
     "1. Use the jupyter notebook built-in functions to read the docstrings of Stack classes and functions \n",
-    "2. Use the `whereis` Stack Club utility to locate DM Stack web documentation.\n",
+    "2. Use the `where_is` Stack Club utility to locate DM Stack web documentation.\n",
     "\n",
     "### Logistics\n",
     "This notebook is intended to be runnable on `lsst-lsp-stable.ncsa.illinois.edu` from a local git clone of https://github.com/LSSTScienceCollaborations/StackClub.\n",
     "\n",
     "## Set-up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What version of the Stack are we using?\n",
+    "! echo $HOSTNAME\n",
+    "! eups list -s | grep lsst_distrib"
    ]
   },
   {
@@ -158,7 +169,7 @@
     "## Online Resources: Searchable GitHub-hosted Source Code\n",
     "\n",
     "All the DM code is housed in GitHub repositories in the `lsst` organization.\n",
-    "It's nice to provide hyperlinks to the code you are demonstrating, so people can quickly go read the source. We can construct the GitHub URL from the module name, using the `stackclub.whereis` utility."
+    "It's nice to provide hyperlinks to the code you are demonstrating, so people can quickly go read the source. We can construct the GitHub URL from the module name, using the `stackclub.where_is` utility."
    ]
   },
   {
@@ -184,7 +195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, `whereis` looks for the named object in the source code on GitHub. You can specify this behavior explitly with the \"`in_the`\" kwarg:"
+    "By default, `where_is` looks for the named object in the source code on GitHub. You can specify this behavior explitly with the `in_the` kwarg:"
    ]
   },
   {
@@ -201,9 +212,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> In case you're interested in what the `whereis` function is doing, paste the following into a python cell: \n",
+    "> In case you're interested in what the `where_is` function is doing, paste the following into a python cell: \n",
     "```\n",
-    "%load ../stackclub/whereis\n",
+    "%load ../stackclub/where_is\n",
     "```"
    ]
   },
@@ -247,22 +258,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here's the `where_is` code, in case you're interested in how the URLs are made (and the markdown display generated). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# %load -n where_is"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Summary\n",
     "In this tutorial we have explored two general ways to read more about the DM Stack code objects: the built-in notebook `help` and magic '?' commands, and the `stackclub.where_is`  utility for locating the relevant part of the Stack source code. \n",
     "\n",
@@ -286,9 +281,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/GettingStarted/FindingDocs.ipynb
+++ b/GettingStarted/FindingDocs.ipynb
@@ -6,7 +6,8 @@
    "source": [
     "# How to Find DM Stack Documentation\n",
     "\n",
-    "<br>Owner(s): **Phil Marshall** ([@drphilmarshall](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall))\n",
+    "<br>Author(s): **Phil Marshall** ([@drphilmarshall](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall))\n",
+    "<br>Maintainer(s): **Alex Drlica-Wagner** ([@kadrlica](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@kadrlica))\n",
     "<br>Last Verified to Run: **2020-07-13**\n",
     "<br>Verified Stack Release: **20.0.0**\n",
     "\n",

--- a/GettingStarted/ImportTricks.ipynb
+++ b/GettingStarted/ImportTricks.ipynb
@@ -9,7 +9,9 @@
    },
    "source": [
     "# Import Tricks: Remote Modules, and Importing Notebooks\n",
-    "<br>Owner(s): **Phil Marshall** ([@drphilmarshall](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@username1)) <br>Last Verified to Run: **2020-07-13**\n",
+    "<br>Author(s): **Phil Marshall** ([@drphilmarshall](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@drphilmarshall)) \n",
+    "<br>Maintainer(s): **Alex Drlica-Wagner** ([@kadrlica](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@kadrlica)) \n",
+    "<br>Last Verified to Run: **2020-07-13**\n",
     "<br>Verified Stack Release: **20.0.0**\n",
     "\n",
     "### Learning Objectives:\n",

--- a/GettingStarted/ImportTricks.ipynb
+++ b/GettingStarted/ImportTricks.ipynb
@@ -9,8 +9,8 @@
    },
    "source": [
     "# Import Tricks: Remote Modules, and Importing Notebooks\n",
-    "<br>Owner(s): **Phil Marshall** ([@drphilmarshall](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@username1)) <br>Last Verified to Run: **2018-08-08**\n",
-    "<br>Verified Stack Release: **16.0**\n",
+    "<br>Owner(s): **Phil Marshall** ([@drphilmarshall](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@username1)) <br>Last Verified to Run: **2020-07-13**\n",
+    "<br>Verified Stack Release: **20.0.0**\n",
     "\n",
     "### Learning Objectives:\n",
     "\n",
@@ -38,9 +38,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/kadrlica/notebooks/StackClub/GettingStarted\n"
+     ]
+    }
+   ],
    "source": [
     "! cd .. && python setup.py -q develop --user && cd -"
    ]
@@ -54,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,9 +83,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "nb-kadrlica-r20-0-0\n",
+      "lsst_distrib          20.0.0     \tcurrent v20_0_0 setup\n"
+     ]
+    }
+   ],
    "source": [
     "# What version of the Stack am I using?\n",
     "! echo $HOSTNAME\n",
@@ -97,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "slideshow": {
      "slide_type": "-"
@@ -139,9 +156,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imported external module 'where_is' (downloaded from https://github.com/LSSTScienceCollaborations/StackClub/raw/master/stackclub/where_is.py and stored in .downloads/where_is.py)\n"
+     ]
+    }
+   ],
    "source": [
     "where_is_url = \"https://github.com/LSSTScienceCollaborations/StackClub/raw/master/stackclub/where_is.py\"\n",
     "so = stackclub.wimport(where_is_url, vb=True)"
@@ -149,9 +174,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<module 'where_is' from '.downloads/where_is.py'>\n"
+     ]
+    }
+   ],
    "source": [
     "print(so)"
    ]
@@ -165,12 +198,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'module' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-9-a8208c20fb3b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mlsst\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdaf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpersistence\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mButler\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mso\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwhere_is\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mButler\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_the\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'source'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/notebooks/StackClub/GettingStarted/.downloads/where_is.py\u001b[0m in \u001b[0;36mwhere_is\u001b[0;34m(object, in_the, assuming_its_a)\u001b[0m\n\u001b[1;32m     35\u001b[0m             \u001b[0mmodulename\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'lsst.pipe.tasks.'\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0mobjectname\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 37\u001b[0;31m     \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobject\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmodule\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     38\u001b[0m         \u001b[0;31m# Locate the module that contains the desired object, and break its name into pieces:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     39\u001b[0m         \u001b[0mmodulename\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mobject\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__module__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'module' is not defined"
+     ]
+    }
+   ],
    "source": [
     "from lsst.daf.persistence import Butler\n",
     "so.where_is(Butler.get, in_the='source')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO2de5Ald3XfP2fuvHZmdndmZ2ffT2ARCAlWeCSQwRhLAovEJZEEO5LLseyC0j8mcULZQYQqcLCpwklVoJIiTlRCthwTBMGm2MSyZSGEsY0ltBJ6v3bZlbQ7+5jRvmZmd3Ze9+SP7rt79+59968fv9vnUzU19/bt7nv6dv/O93d+5/cQVcUwDMPIL11pG2AYhmGkiwmBYRhGzjEhMAzDyDkmBIZhGDnHhMAwDCPndKdtQDusXbtWd+zYkbYZhmEYXvHEE0+8oapjldu9FIIdO3awd+/etM0wDMPwChF5rdp2axoyDMPIOSYEhmEYOceEwDAMI+eYEBiGYeQcEwLDMIyc40QIROReEZkUkedqfC4i8l9FZL+IPCMi7y777A4R2Rf+3eHCHsMwDKN5XEUEfwLcXOfzjwC7wr87gT8CEJE1wOeB9wDXAZ8XkRFHNhmGYRhN4EQIVPWHwMk6u9wK/KkGPAoMi8hG4BeBh1T1pKqeAh6ivqAYhmEYjklqQNlm4FDZ+8PhtlrbL0NE7iSIJti2bVs8VkZlbg5++lOYnYWREXjzm6HbjzF78/Nw6hTMzMC5c8H7paXgs64u6O2FgQFYuRKGh2FwMF17m0YVDh+GI0eCe7FzJ6xZk7ZVxtmzsH9/UGbWrg3uS6GQtlW5xQ8vBajq3cDdAOPj49lbTefUKXjsMVhcDN5PTcHEBPzsz0J/f7q21eDMmcA/Hj8eCEAr9PXB+vWwcSOMjYFIPDZGoliEJ5+Eo0cvbjtyBK6+GmyKkvSYmoLHH4fl5YvvjxyB9743qHEYiZOUEEwAW8vebwm3TQAfrNj+g4RscsfcHPz4xxdFoMTZs4E4vP/9mantFItBBfngQZiebv888/Pw+uvBX18fbN8e+Na+PmemRuf55y8VgRLPPhuI84YNyduUd2ZmLhWBEmfOwN69cP31Ga1VdDZJdR/dA/x62HvovcAZVT0KPAh8WERGwiTxh8NtfvHUU7CwUP2z6Wl46aVk7alCsQivvgoPPwxPPx1NBCqZn4dXXoHvfS/wvbV+ikSZnAwuuBZPPx0YbiRHKUKrFIESJ04ETatG4jiJCETkGwQ1+7UicpigJ1APgKr+D+AB4J8A+4FzwG+Gn50Ukd8HHg9P9QVVrZd0zh4TE/DGG/X3OXgQtm0LGthTYHISnnsuCFDipFiEAweCKOGKK4Jm31Qqd8ViUOuvx8JCINDvelcyNhmBMDeqgbzyCmzZktnm1E7FiRCo6u0NPlfgt2p8di9wrws7EqdYbK62rxrsd+218dtUxsJCIAATE4l+LUtLQWRw6BDs3g2rVyf7/bz2WpDxbsShQ0FCf2gofpvyztIS7NvXeL/l5UAM3vnO+G0yLmAji6Nw5EhzDgfg2DG37TENmJyEH/wgeREoZ3oa/u7vgvKvSaX3i8WgN0ozqDbnnIzovPZa822Ghw7B+fPx2mNcgglBFFptz0yg/VMVXnwxyFFnoQm8FAw99lhCuYMjR1pzIhMT5nTiptRm2Mr+Bw/GZ49xGSYE7XLyZOs1/CNHYvWGCwvw6KPNV4iTZGoKfvjDoHNIrLTqQFSD2qoRH8ePty62r70WCIKRCCYE7dKO8ygWg7A3Bs6ehb//+8Z56zSZm4N/+IeglSwWpqfh9OnWj3v99QTbrnJIO2VlcbF6118jFkwI2mFpqf2HNAYhOH06EIG4ewW5YHk56C4eSyW83d/2/PlsK6jPzM0F4WA7xFRpMi7HhKAdjh6t3Re6ETMzTpPGb7wBP/pRRvruN4kqPPOM4zytarTM+OHD7mwxLhLlnkxNWf4mIUwI2iFqVxxHXXkmJ4MkbLualDYvveRwrN2JE9Gy41HE3ahN1Gf9yBE3dhh1MSFolcXF6M0IDto+S9O1+J5P27fPkRhEdRjLy4GyGu44ezZ69GtCkAgmBK1y7Fj0xGLEAnLiRDC1ke8iUGLfvojNRKpuMtCxZbFziotk76lT1jyUACYEreLKWbR5njNnOksESrz0Uv2pgepy6pSbQRPHj3feD5smrsrK8eNuzmPUxISgFYrF9ntAVNJGISlNZlpaJ6DTePbZNiuRrhzF4mIgKkZ0SgtcuMCEIHZMCFrhxAl3CcUzZ1qqxS4sZGe0cJw8+WQwVq8lXDoKczpucJlvmZqyRH7MmBC0gmsn0WRhKRaDxLAP4wSiUrrWZqdwYm6u9VV16mEJYze4/B2LxaASZsSGCUEruGoWavF8zzzTRi3ZYxYWgjxIU01gru/JzEwgLkb7qLq/LybQsWJC0Cxzc8FaxC6ZmmrYA+nAgXwOsJyZCZqJGnbQcu1w4jpnnjhz5vLV+qJiI79jxYSgWeJwDgsLdbuRvvEGvPCC+6/1hePHg6npa6Iaj4MwpxONOMrKzIx1I40RJ0IgIjeLyMsisl9E7qry+ZdF5Knw7xUROV322XLZZ3tc2BMLcTmHGuc9fx6eeMLmQnvllTqpmenpeObWMCGIRsJlxYhOZCEQkQLwVeAjwJXA7SJyZfk+qvrvVHW3qu4G/hvwF2Ufz5U+U9VbotoTGwk+3MViIAI+zR8UJz/5SY3kcVwJxPl5twnoPFEsxpfQMiGIDRcRwXXAflU9oKoLwP3ArXX2vx34hoPvTY7Z2fj6bZ48eVm1/6WX8pUcbsTiYiCMl431itMxWC+V9jh1Kr5BeSYEseFCCDYD5enMw+G2yxCR7cBO4Ptlm/tFZK+IPCoiH631JSJyZ7jf3qmkk3lxOoWlpUtWa5mcTGQhM+84fbpiTiLVeNXShKA94vzd5uasR1dMJJ0svg34tqqWjw7ZrqrjwK8CXxGRN1c7UFXvVtVxVR0fGxtLwtaLxO0UwvPPzwfNIEZ1fvrTsl6EMzPue6aUY0LQHnGHsnZfYsGFEEwAW8vebwm3VeM2KpqFVHUi/H8A+AFwjQOb3BL3w33yJKqBCFheoD5PPRW20sXtEObn8zGCzyVx5gdKWJtpLLgQgseBXSKyU0R6CZz9Zb1/RORtwAjwj2XbRkSkL3y9FngfkK0Ok0mEoydOcPCgdV9vhvl5ePppknEI5nRaY3o6/qkgLCKIhchCoKpLwCeBB4EXgW+p6vMi8gURKe8FdBtwv+olmdG3A3tF5GngEeBLqpotIUjAGcxNL/LKk44Hq3Uwx4/D5EsJOGlzOq2RhHDOzlrYHAPdLk6iqg8AD1Rs+1zF+9+rctyPgKtd2BAbMc9GWSwGo4e7151kcWwo1u/qFLrm53j9lfOsvhr6+mL8IpuJtDWS+r1OnYL165P5rpxgI4sbEXMt5+jRoCm6Z9acTrP0zp68IKCxDribnY03Id1pJNWUZgLtHBOCeiwvO11ovpJz5y6uxGdC0Dyl32pmBo7HPReZ5QmaY24uuSkgTAicY0JQj9OnY6tyql5ao+2em0GWrPbZDOWiefhQzGs0nD7deB8jWed86pTNveIYE4J6xPhwHz16+bQJPWfN6TSkWKT73HT5Ww4ejPH7rPbZHEn+TsvLNgWIY0wI6hFTbfD8eZioMtLChKAxPefOIHrpFAbT0zF2vY0xKuwoko6cLFJziglBPWKq5bz6anXfYnmCxnTPVncAr78eU153cdEGljWiWEzeMVuk5hQTglqcPx9L8mtqqnb+2SKCxvSere4AlpcDMYgFq33WZ3Y2vonmamH3xCkmBLWI4UFbXKy/2ljX4jxd8zapVj1qRQQQjP8qm7/PHeZ06pNG7Xxmxha0d4gJQS1iKPyHDjVeh9eigtrI0iLd8/WbaV59NYbKqQlBfdL4fVRjUv18YkJQC8cP2cxMc9Op95yzh7sWzfw28/NBjyynnDljCeN6pOWQTaCdYUJQC4cPmSq89lpz+9Zr+sg7zf42R444HltQLFp3xVoUi7EOuqyLRQTOMCGoxtyc04mtjh+vsdRiFaxpqDbNRkutCG/TmNOpzvR0etGSRQTOMCGohsNCv7hYfcxALbqWFynMN6kaOaP7bPP35fRpOOXST5jTqU6aAjk72zjpZjSFCUE1HBb6Q4da79zQisPLC80kiit5/TWHiWOLCKqTtkCm1SzVYZgQVMNRoZ+dbW+9bUsYX075tBLNMj8Px445MiDNJpAsk7ZApv39HYIJQTUcPFyq7Q9wsojgctoVxyNHHKV7lpcDZTcukoUkugmBE5wIgYjcLCIvi8h+Ebmryue/ISJTIvJU+PeJss/uEJF94d8dLuyJxPy8ky4nJ0607zcsIricdsWxWKw/iK8lzOlcShojiiuxe+KEyCuUiUgB+CrwIeAw8LiI7Kmy5OQ3VfWTFceuAT4PjAMKPBEem95EIg4erOXlaM6na3GersV5ij1xLr/lF1HE8cSJYEGroagLwFl79KVkwQnPzARi1GWNG1Fw8etdB+xX1QOqugDcD9za5LG/CDykqidD5/8QcLMDm9rHwcN99Gj0CdCseaiM5WUK56M1yziZhygLji9LZEEYVdNvnuoAXAjBZqC8/ns43FbJvxCRZ0Tk2yKytcVjEZE7RWSviOydim3OYSI/3AsLbhKU7SRHO5XuuRkkYqJ2dtbBWvQmBJeSld8jC4LkOUnFU/8X2KGq7ySo9d/X6glU9W5VHVfV8bGxMecGXiDiw33okJtmU8sTXKRnzk1BP3w44r1ZXAwGGxoBWXHAWREkj3EhBBPA1rL3W8JtF1DVE6paysDeA/xMs8cmyvJypLnnz551UOsMsYjgIq6ayebng1HekciK80ubc+diWgCiDeyeRMaFEDwO7BKRnSLSC9wG7CnfQUQ2lr29BXgxfP0g8GERGRGREeDD4bZ0iPhAOeudAhTmz9o0uyEuRfHIkYj+y5xOQJZ+hyzZ4imRew2p6pKIfJLAgReAe1X1eRH5ArBXVfcA/0ZEbgGWgJPAb4THnhSR3ycQE4AvqOrJqDa1TYQH6tRpt8+jqNI9N8PS0LC7k/qIqrOmIQi09chR2L6tzRNYM0RAlpxvqcluxYq0LfGWyEIAoKoPAA9UbPtc2evPAJ+pcey9wL0u7IhMmw+3Khx2GA2U6Jmbzr0QFBbmkGW388lMHocN66Gvnd65WXKAaZK13+HMGROCCFjn23LafLjfeCOeHKLlCeL5DVSDxHFbnLUmOyB7QpA1ezzDhKCcNh6m5eUITqUBNpYgPjE8cSJCv4C8O52lpUidKmLBxhJEwoSgxLlzbU1pe/x4fJ0nuufs4Y4zKmo7uZ93p5PF68+7OEfEhKBEGw/S0lIMyyKW0bW8mPvF7OMUgunpNnO/eXc6Wbx+a7KLhAlBiTZqOUePxv/s5TpPsLzc8hoErdJWVJBFR5gkWYwIbKqJSJgQlGixcLuaSqIRLrtO+kYSTWPnzsHJVjss510Isnr9JgRtY0JQosWHe2IimXVK8pwnSEoEDx1q8V4uLsL587HZk3myKgRZtcsDTAggmICmhV4Q58/DVBsrj7VDnpuGCgmJ4Px8GyvJ5bX2ef58dqaWqMSEoG1MCCCYmrKFKuHEBMHqCQlQOJ+BxT9Sovtccs52YqLFnzmvTifL151XcXaACQG09HCfO+duYrlmEFW6I87F7ytJ5kcWFmBysoUD8up0snzd8/OO1iXNHyYE0NLDfTiFuVHzmCeQxQW6FqMvGdoKLfUCy3LNOE6yLASQ3/sSERMCaPrhmZ2F0yksoplHIUjjmhcXW5imemYmmd4CWSPrjjbrQpVRTAig6YcnrqkkGpFU0jRLpJUkP3q0yQHmxWLQTpgnVIPaUJYxIWgLE4KlpaZmjJuZSa8y1JPDnkNpRUHLyy2MD8mb0zl3Lvujd/N2TxxhQpDxaACgMO9BAXRMms1hx483GRVkvZnENT442bzdE0c4EQIRuVlEXhaR/SJyV5XPPyUiL4SL1z8sItvLPlsWkafCvz2Vx8ZOEw/39HT6ZSBveYI0r7fpqCDthyJpfLjeJiN841IiC4GIFICvAh8BrgRuF5ErK3b7CTAeLl7/beA/lX02p6q7w79botrTMk083GlGAyXyJARdC+fpWk530NKxY02Mm/LBMbrEl+v1xc4M4SIiuA7Yr6oHVHUBuB+4tXwHVX1EVUuZtUcJFqnPBg1CyTNnspEfy5MQZOFai8UmZpadzdlgP1+aXUwIWsaFEGwGyudwPBxuq8XHgb8qe98vIntF5FER+Witg0TkznC/vVNTU9EsLqfBQzORwriBamTBOSZFVqbVmJxsEBWoZm+BlrhocRqWVDEhaJlEk8Ui8mvAOPCfyzZvV9Vx4FeBr4jIm6sdq6p3q+q4qo6PjY25MWhxMRiNWIPTp7MRDUDOhCAj11osBgvd1yUvTufcOX+in7zcE4e4EIIJYGvZ+y3htksQkZuAzwK3qOoF76uqE+H/A8APgGsc2NQcnkQDEM8i7lklK0IAwUL3dWctyIvT8ek68zrYLwIuhOBxYJeI7BSRXuA24JLePyJyDfA/CURgsmz7iIj0ha/XAu8DXnBgU3PUebhPnc5eJJwlBxknWZpbSRWO1utB5JODjIJP17m8bD2HWiSyEKjqEvBJ4EHgReBbqvq8iHxBREq9gP4zMAT8n4puom8H9orI08AjwJdUNRNCMJGBnkKVFOay4yDjoms+e5FP3ajAJwcZBd+u0zd7U6bbxUlU9QHggYptnyt7fVON434EXO3Chrao8bCcOp3N2QPyEBFk8RpLUcH2bVU+PHs2aDvv6vCxmb451tlZWL8+bSu8ocOf3gbUeLizGA1ANp2ka7J6jTWjgjz0HPKpx1AJ34QrZfIrBAsLVXsMZTUagOw6SZdk9Rrr5go63emUoh6f6PR74pj8CkGNfqFHMtRTqJI89BzKqhBAnaig052Oj9dnPYdaIr9CUOXhzmJPoUqy7ChdkKUeQ5XUjAp8dJStkJXBNK2wvBysr2w0hQlBGVmOBkp0cs+hLPYYqmTyeJXRxj46ylbwVeh8tTsFTAhCTnsQDUBnRwRZjgZKqFaZg6jT5xzy1aH6ancK5FcIKmpxR46kZEeLdLQQeHJtl81B1Mk9h3y+NhOCpsmnECwuXtJ+mJUZRpvBF2fZDr5cW7FYZb0CXx6gVvGxx1CJTr0nMZBPIaioKWRpTqFGdHLPIV+EAIJVzC6JCjq19unzdflse8LkUwjKagrT0/5VHDo1YezTdRWLgRhcoFOdjm+Fo5ylJes51CT5FIKyQutTNFDCh6Rqq2RhVbJWuWRtY58dZj18Fzjf7U+IXAvBzIyfz4lPTSjN4qO4XbK28exsZw5g8rGAlOO7/QmRTyEIa28+RgMABQ+dZiMK5/wssBeigmIxu3OTtIuq/5GOCUFT5E8IlpZgbo7ZWX+WYK2k21OnWQ9fo5zl5bJcQac5HZ9WJauF70KWEPkTAs+jAYDCwrnAA3UQPjYNlTh2LLwdnSYEneBEO+2exET+hGBmhtnZYOyAr4gq3fOeDvKpga8RAZRFBZ3gOMvpBCdaMWbIqI4TIRCRm0XkZRHZLyJ3Vfm8T0S+GX7+mIjsKPvsM+H2l0XkF13YU5eZGW9GEdfDZ8dZiSwu0LVUb2Hg7HPsGCyf7px7AnSGEEDnCXQMRBYCESkAXwU+AlwJ3C4iV1bs9nHglKq+Bfgy8IfhsVcSrHH8DuBm4L+H54uN2WOznD4d5zckQycJQSdcy9ISTB7osJ5DneJAO0XQYsRFRHAdsF9VD6jqAnA/cGvFPrcC94Wvvw3cKCISbr9fVedV9SCwPzxfbEy81BkPhU+DrxrRCUIAcGximeXZDlo0vVMcaKcIWoy4WLN4M3Co7P1h4D219lHVJRE5A4yG2x+tOHZztS8RkTuBOwG2bau2eGxz7Pz1n2v72Eyhivztg2lb4QS98SoYi79VMAkOf+95pp6fTNuMyBT7VnD6bTeBpG1JdLr2zzO8pzPKyttu283Qm92vxexk8fokUNW7gbsBxsfH246/e4d6ndmUKsUiyJL/3fsAVvZBh9yXDdv7mHxywfsWovne1cxrZ9yTLlWK5/3OQQGsXg1D6wZiObeLpqEJYGvZ+y3htqr7iEg3sBo40eSxRjW6umAgnocicYaG0rbAGX1rV7J2bdpWRGdpYGXaJjij2NNHsdt/Udu8RWBwMJZzuxCCx4FdIrJTRHoJkr97KvbZA9wRvv4Y8H1V1XD7bWGvop3ALuDHDmzKBys7oLD29EB/f9pWuGNoiE2bQDxvUlle0QHPVhlL/X5XNlatgqH1g0EFMAYin1VVl4BPAg8CLwLfUtXnReQLInJLuNvXgFER2Q98CrgrPPZ54FvAC8BfA7+lqp01UipOOkEIOigaAGDlSvr68D4q8N1xVrLkubBt3kysZcVJjkBVHwAeqNj2ubLX54FfrnHsF4EvurAjd3SCE+0EMSunuxv6+9m06TxTbwCe5gp8d5yVLK/wt6ysXBkWkxjLSv5GFncSneBEO+EaKilFBaNpG9IexZ4+tLsnbTOc4rOwbS71ozQhMKoyNOR/Y3QnRDWVhAV20ya87H7ps9Osha/XNDQU5AcuvIkJEwKf6YSeQ50YEYQFtr8fRtekbEsb+Oo061Hs7UcL3vSWv8CFaEDEhMCog8+OtLsbVqxI2wr3lN0TH6OCThQC8O+6hoaCsQNAUE4K8c2+Y0LgOz4LQSc2C8El92TFClgzkqItbdBpPYZK+HZdmzaVvYm5nJsQ+I7PztRnEatHTw/09V14u6nqpCnZxbeac7P4dF2DgzA8XLbBhMCoi8/O1GcRa0TZfRlYASOeRAXF7l60x/9RuNXwSQguqzzEXFZMCHzH555DPotYIyqubbMnUYFPzrJVfLm2gQEYGa7YaBGBUZdCwd+EaycLQUUNbmAAhj2ICnxxlu1Q7FvhRc+hqpUGiwiMhvjoUAsF/7u+1qPKPdm8qcp+GaOThQCynzAeGKjSjLhiRdDDLkZMCDoBH4Wgk/MDUPWeDA5mPyrweSqGZsi60FWNBhIo3yYEnYCPQuCjza3Q2xv8VZD1qCDrjjIqWb6+qtEAmBAYTeKjU/XR5lbxLCoodvdS7OlrvKPHZLlpaFOtSoIJgdEUPjaz5FQIILtRQZZry65YzuiCOwMDsKbWdCQmBEZT+Jh4zbEQXDZYKCNkubbsiuW+AbQrvqka2qVmNACJVPRMCDoFnxyrj8LVDnXuSRbHFeQhIoDsXWfdaCCBHkMQUQhEZI2IPCQi+8L/l7V+ishuEflHEXleRJ4RkX9Z9tmfiMhBEXkq/NsdxZ5c45MQ+NiU1Q517kkWcwVZbTZxTdaEoG40kFC5jhoR3AU8rKq7gIfD95WcA35dVd8B3Ax8RUTKA+PfVdXd4d9TEe3JLz4JgU+2RqG395I5hyrJWq4gaw4yLrJ0nXWjAfBGCG4F7gtf3wd8tHIHVX1FVfeFr48Ak8BYxO81KvHJufpka1Q8iQry0GOoRJaEoGEToSdCsF5Vj4avjwHr6+0sItcBvcBPyzZ/MWwy+rKI1HwSReROEdkrInunpqYimt2B+DTnkAnBBbZkJFeQJecYN1m51prjBsrJihCIyPdE5Lkqf7eW76eqSp2lukVkI/C/gN9U1WK4+TPA24BrgTXAp2sdr6p3q+q4qo6PjVlAcRk+JWAvrL2XAxoU5IZNAwmRFeeYBFmZc2jzliZ2SkgIGv4aqnpTrc9E5LiIbFTVo6Gjn6yx3yrgL4HPquqjZecuRRPzIvLHwO+0ZL1xKStXwtmzaVtRn05dlawWTRTkTZvh5CnqVKPiJ09CAMH19syeSu37BwerzDBaycBArKuSlRO1aWgPcEf4+g7gu5U7iEgv8B3gT1X12xWfbQz/C0F+4bmI9uQbH5pc8tJjqEQT92RgRfprG+dRCNJkS4aiAYguBF8CPiQi+4CbwveIyLiI3BPu8yvAB4DfqNJN9Osi8izwLLAW+IOI9uQbH4QgT81CEKxW1t/fcLfNm0l1beOlgXzdlzSF4JK1iOuRYFmJ1FCmqieAG6ts3wt8Inz9Z8Cf1Tj+hijfb1TggxD4YKNrVq6E8+fr7tLfD2tH4Y03ErKpjOWefrS7J/kvTpE0haCpaAC8igiMLOFDz6G8CkETbN6czu1Lu5kkDdK65lWrWqjomxAYbdHVlf02+DwKQZMlv68P0ugQt5STEcXlFHv7KXYnvzZz09GASKJl2YSg08iyo+3tbaq9vONo4Z5s2hToeZIsrchXfqBE0lHB8HALvn1wMNEHwYSg08hyMjbLIhUnK1c23ebT2wvr1sVsTwV5bBqC5K+76WgAEi/HJgSdRpadbZZFKk5aHOy3cWNi3cdRkfwKQYI9pUZHWxzvaUJgRCLLzjbLIhU3LVx7Tw9s2BCjLWUs9yY3aClrJCaA0sa04wmXFROCTmNgIJH5y9siyyIVNy1e+4YNydzGvI0fKCepax9b20ZqzCICIzJZrXln1a4kaLFgFwoN5ql3RF6bhQC00M1yb7zTnXR1tRENdHcnPm+YCUEnkkWHm+VIJQnauCfr1gXJ4zjJc0QA8V//+vVt3MMUyq8JQSeSxSaYLNqUJIODLbfFd3W12NOkDUwI4rv+QiFI/LeMCYHhhCw63SxGKUki0tZv0HJvkxbQrgLLfZ5MXR4TizGOodi0qc0gOIXya0LQiWRRCLJoU9K08RuIxBcVLK1ofnxDpxJXRNDbGzQLtUVTM9K5xYSgE2lyxstEMSFoOyoaHo7n58t7sxDAcv8g2uW+++zmzREGBlvTkOGMFGoVNSkUgjbyvBPhnmzd6tCOkDibRbwhhgF1AwOwdm2bB69YEVTkEsaEoFPJUg28hSkWOpoI92RwMMgXuGRpMEOVhRRxHRlt3RrhcU+pAhdJCERkjYg8JCL7wv9Vl2IWkeWyRWn2lG3fKSKPich+EflmuJqZ4YIsCUGWopM06emJtEznli1u9dSahgJcRkarVkV83FMqt1EjgruAh1V1F/Bw+L4ac6q6O/y7pWz7HwJfVtW3AKeAj0e0x6YNTEIAABCqSURBVCiRJeebJVFKmwi/RV+fu6knlvsGMrGAexZwFhkJbNse8RyeCsGtwH3h6/sI1h1uinCd4huA0jrGLR1vNCDBha8bYkJwkYgC3XaXxAoWLRq4gKvIaGxtsP50JDwVgvWqejR8fQyo1WGqX0T2isijIlJy9qPAaVVdCt8fBmoOxhaRO8Nz7J2amopodg4QyYYDFslWdJI2Ee9JodDGlAVVWBqwe1JCC92Rx1MUCg66+XZ3p9apomHdQkS+B1QLSD9b/kZVVUS0xmm2q+qEiLwJ+H64YP2ZVgxV1buBuwHGx8drfY9RzurVcOpUujZkKTLJAg5Ecd06mJyEubn2z2H5gUtZHFhNYf5c28dv3Oigs0+KFbeGQqCqN9X6TESOi8hGVT0qIhuByRrnmAj/HxCRHwDXAH8ODItIdxgVbAEm2rgGoxZZqIlnwYYsMTAQeIzFxbZPIQLbtsHLL7dvxqJFBJewNLgaTh1tvGMVnOVuUiwrUZuG9gB3hK/vAL5buYOIjIhIX/h6LfA+4AVVVeAR4GP1jjcikIWmIROCy3FwX1avDgaatUOxu5diX7yzbvpGlJ5DW7c6WlXSYyH4EvAhEdkH3BS+R0TGReSecJ+3A3tF5GkCx/8lVX0h/OzTwKdEZD9BzuBrEe0xylm1Kv3++yYEl+PoN9m2rb3ba9HA5bTbc2jVKlizxpERKZaVSP0PVPUEcGOV7XuBT4SvfwRcXeP4A8B1UWww6tDVFQzmmp5OzwYTgstptypfQX9/0CRxtMUWDRtIdjnF3n6KPX10Lc43f5CL7qIlSmU1JWxkcafjyOm0xYoV8U+o7yMOxXHTptaTlBYRVKfV32X9OgfdRUukHL2bEHQ6adbILRqoThtrE9SiUAiaiFrBIoLqtPK79PS46cZ7gZTLiglBp5PmA5ZmNJJlHI+tGB1tPv9cLPSw3G8TAFZjcbD553XLFscL7qVcVkwIOp3Vq9MLOS0iqI3jgr99e3O32aKB2jQrBENDMDbm+MstIjBiJc0klEUEtXFc8FesaK4veyu13rxRShjXRWDHDsdfnHKiGEwI8kEaDtkSxfWJ4Z5s2hQMbqqHCUF9Gv0+G9bHsHTo6tWOBiK0jwlBHkhDCEaqzkhulBgactzIHCaOG3RnNCGoT73fp7fXcYK4RAYiZxOCPJDGg5aBhzvzxPAbjQzXHuBU7OmzEcUNqCcEO3bENG1WBsqKCUEeWLUq+YnfMvBwZ56Yoqbt26vfbosGGrM4VP2erFkT4yOdgbJiQpAHkp4KWiQTD3fmiek36umpPraglpMzLqLdPSz1Xdq9tlAIxDUWenqCZsKUMSHIC0k65pUrberpZogxjzI2dvnYAosImqNSMLdvj3E9+YxUmEwI8kKSyVtLFDdHX1+kNYwbsXPnpXpsQtAc5UKwejWsXRvjl2WkrJgQ5AVnUyQ2QUYebi+I8b709V1cNWtpxUq0O65qbWdREoJCIRDTWMlIWTEhyAv9/bHWPi8hSdHxnZgdwfr1QROR5QeaZ2lgFdpVYPv2BIbCmBAYiZPEQ9fXl9q6q16SgGju3Ak6YuLcNCKs3DYSb5MQBLm02JIPrWFCkCeSqKlnpIbjDatWOR9YVklfH7z1vSYEzdLXB2+5NoHnOEORcyQhEJE1IvKQiOwL/1/264nIL4jIU2V/50Xko+FnfyIiB8s+2x3FHqMBSTx4GXq4vUAkfvHs62PTrsF4RsV2ILt3Q+/G0fi/KENlJWpEcBfwsKruAh4O31+Cqj6iqrtVdTdwA3AO+JuyXX639LmqPhXRHqMeCdQ+s/Rwe0Pcv1l4/quvTi5N5Cs7d8K6dQTiHPesvRkqK1GF4FbgvvD1fcBHG+z/MeCvVPVcxO812kEk3oevUMhMv2iviNshjAa1254eePe701/GOqusWgVXXhm+6e5ufpGHdlixIobZ69onqhCsV9XSiqnHgPUN9r8N+EbFti+KyDMi8mURqTl3oojcKSJ7RWTv1NRUBJNzzmiMIe+aNeZl2mFkJN7ZJ8vu+Zo1cMUV8X2Vr3R3w8/8TMVtiLOsxHnuNmj49InI90TkuSp/t5bvp6oKaJ3zbCRYxP7Bss2fAd4GXAusAT5d63hVvVtVx1V1fMz5qhA5Is6uEBl7uL2hUIgvT9Dbe1nNdteusPnDuMA731llpocclZWGDcaqelOtz0TkuIhsVNWjoaOfrHOqXwG+o6qLZecuRRPzIvLHwO80abfRLqtXB9WfpSX35469v10HMzoKJ07Ec94qXHMN/PCHMDfn/it9Y/v2GtNLlyJcrVm/bZ+MlZWo8ege4I7w9R3Ad+vsezsVzUKheCAiQpBfeC6iPUYjROKpjXR3W34gCnE5hhrn7e2F8fHU10NJnZERuOqqGh/29MQzWePAQKbyAxBdCL4EfEhE9gE3he8RkXERuae0k4jsALYCf1tx/NdF5FngWWAt8AcR7TGaIY6mtdFRyw9EYWQknon66tzr4eGgSSSv9PU1IYZxlJWMRQPQRNNQPVT1BHBjle17gU+UvX8VuCz4UtUbony/0SZxPNyWt4lGV1fgII4fd3fOFSsajvLeuhXOnIGDB919rQ90dcG11wYzr9RlbAz27XP75RksKzkPDHPK0JD7DuWWfYyOawfR5D15xzvyd/ve9a4m8/MjI27H3oiYEBgZwmXJHxy0+YVc4NobN3k+kaDrZJzd5rPEW996cVbWhpQiNVeMjGRmfqFyTAjyikunk7fqZFy4FNQWHVh3N7znPU00lXjOli1tjKNY32h4VAtktKyYEOSVsTF3yUmXBSXvuPotR0dbbtLo74f3vjeTFVYnrFsXzCPU1oGuyGhZMSHIK4WCm5C3pydzg2O8ZuNGN+fZsKGtw1auDCKDuKekSpo1a4IeQm11bOvvd9M1emAgs+1vJgR5xoXTWb/eOqO7ZGQk6NcYlTaFoGTCddd1zrLTw8OBuEW6HhdlxZXIx4CV4DyzYUN0J57hh9tLRKL/pmvWRG7sHx3tDDEYHg6auyJHOCYERsfS0xOtK1tPT2aTX16zaVO6x4esXet3M9GaNXD99Y5yHoOD0ZqHBgYyvWiTCUHeabofXRU2brRmoTgYHW1/nEdXV42Jc9o35frrE1i71zHr1jmKBMqJ8rtmfFUgK8V5Z8OG9qtMW7e6tcW4SLsCvW6dc689PAzvf78/Q0W2bYupWWvLlvYrPhkvKyYEeaerqz2nMzSUqRWWOo5t29rr4rJtm3tbCETg534uk9PkXEAkWFjmXe+Kadqr3t72kvCjo5lXURMCA3bsSOYYo3kGBlrPv7RzTAv09ATNLW96U2xf0Ta9vUE+481vjvmLOrSsmBAYQe2+FQfS0xNbzdMoo1WP+6Y3xT4DrEgwN9G112YnbzA6Cj//8wlN4TM62trU1AMDme4tVMKEwAjYtav5fd/0Jv/7FfrA2rXN9zTp60tUnDdsgA9+MNJwhcgUCoEoXX99wlNjvPWtze/7lrd4MT27CYERsGZNc8Pf+/qy2TbQqbz97c3tt2tX4uLc1xdEBuPj7iezbcS6dYEQJRAEXc6GDc11JR0czHySuIQJgXGRd7yjca+It7/d347lPjI62nhcwKpVqbZDb9wIv/AL8La3xT9P0erVQZ7iPe9JeZGvq69urEBXXeVN9+pIVorIL4vI8yJSFJHxOvvdLCIvi8h+EbmrbPtOEXks3P5NEclIq2NOGRwMul3UYsMGb2o4HcXVV9du+ygUggWIU25+KBSCoOSmm4JHyHWEUBrc9oEPZGQ6/+HhoNmnFtu2eTXYMqpcPQf8c+CHtXYQkQLwVeAjwJXA7SJS8jZ/CHxZVd8CnAI+HtEeIyo7dwZ/lQwPBw7HSJ7e3qBjfGV1u6sL3v3uTE1k1t0d9Ny58cbAcW/d2n5SeeXKoDn+hhuCPEDm/OoVV1SP1sbGAvH2iKhLVb4IIPVrI9cB+1X1QLjv/cCtIvIicAPwq+F+9wG/B/xRFJsMB1x1VRCDHzgAS0vBw/7Wt1qCOE1Wrw6qwy++CCdPBl7yiisyO22BSOC4160DVZieDsyenoZz5+D8+eDRKhaDx6qnJ4gihoaCSx0d9WBtBJFAiEdG4PXXg4vZujVQQk+ahEok0di7GThU9v4w8B5gFDitqktl22uOwxaRO4E7AbZZ18X42brVmoGyxsBAsJSYZ4gEzr2VXpfeIBJkrD3vQNFQCETke0C1TmKfVdXvujepOqp6N3A3wPj4uCb1vYZhGJ1OQyFQ1ZsifscEUF613BJuOwEMi0h3GBWUthuGYRgJkkRD1uPArrCHUC9wG7BHVRV4BPhYuN8dQGIRhmEYhhEQtfvoPxORw8D1wF+KyIPh9k0i8gBAWNv/JPAg8CLwLVV9PjzFp4FPich+gpzB16LYYxiGYbSOBBVzvxgfH9e9e/embYZhGIZXiMgTqnrZmC+/+jgZhmEYzjEhMAzDyDkmBIZhGDnHhMAwDCPneJksFpEp4LU2D18LvOHQnKTx3X7w/xp8tx/8vwbf7Yd0rmG7ql42bZ+XQhAFEdlbLWvuC77bD/5fg+/2g//X4Lv9kK1rsKYhwzCMnGNCYBiGkXPyKAR3p21ARHy3H/y/Bt/tB/+vwXf7IUPXkLscgWEYhnEpeYwIDMMwjDJMCAzDMHJOroRARG4WkZdFZL+I3JW2Pa0gIveKyKSIPJe2Le0gIltF5BEReUFEnheR307bplYRkX4R+bGIPB1ew39M26Z2EJGCiPxERP5f2ra0g4i8KiLPishTIuLd7JMiMiwi3xaRl0TkRRG5PnWb8pIjEJEC8ArwIYJlMR8HblfVF1I1rElE5APALPCnqnpV2va0iohsBDaq6pMishJ4AvioL78/gASLcw+q6qyI9AB/D/y2qj6asmktISKfAsaBVar6S2nb0yoi8iowrqpeDigTkfuAv1PVe8I1WgZU9XSaNuUpIrgO2K+qB1R1AbgfuDVlm5pGVX8InEzbjnZR1aOq+mT4eoZgbYqaa1RnEQ2YDd/2hH9e1aREZAvwT4F70rYlj4jIauADhGuvqOpC2iIA+RKCzcChsveH8cwRdQoisgO4BngsXUtaJ2xWeQqYBB5SVd+u4SvAvweKaRsSAQX+RkSeEJE70zamRXYCU8Afh81z94jIYNpG5UkIjAwgIkPAnwP/VlWn07anVVR1WVV3E6yxfZ2IeNNMJyK/BEyq6hNp2xKR96vqu4GPAL8VNpv6QjfwbuCPVPUa4CyQer4yT0IwAWwte78l3GYkRNiu/ufA11X1L9K2JwphOP8IcHPatrTA+4Bbwjb2+4EbROTP0jWpdVR1Ivw/CXyHoNnXFw4Dh8siyW8TCEOq5EkIHgd2icjOMEFzG7AnZZtyQ5ho/Rrwoqr+l7TtaQcRGROR4fD1CoKOBy+la1XzqOpnVHWLqu4geP6/r6q/lrJZLSEig2FnA8ImlQ8D3vSkU9VjwCERuSLcdCOQeoeJ7rQNSApVXRKRTwIPAgXgXlV9PmWzmkZEvgF8EFgrIoeBz6vq19K1qiXeB/wr4NmwjR3gP6jqAyna1CobgfvCHmhdwLdU1csumB6zHvhOUK+gG/jfqvrX6ZrUMv8a+HpYIT0A/GbK9uSn+6hhGIZRnTw1DRmGYRhVMCEwDMPIOSYEhmEYOceEwDAMI+eYEBiGYeQcEwLDMIycY0JgGIaRc/4/CpInenkzBnEAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Imported external module 'fill_demo_features' (downloaded from https://matplotlib.org/mpl_examples/lines_bars_and_markers/fill_demo_features.py and stored in .downloads/fill_demo_features.py)\n"
+     ]
+    }
+   ],
+   "source": [
+    "mpl_url = \"https://matplotlib.org/mpl_examples/lines_bars_and_markers/fill_demo_features.py\"\n",
+    "mpl = stackclub.wimport(mpl_url, vb=True)"
    ]
   },
   {
@@ -178,35 +254,6 @@
    "metadata": {},
    "source": [
     "Here's another example - a simple python gist:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "timer_url = \"https://gist.github.com/qewbicle/2397e65fd894884c2d6ccba21ec2a194/raw/310187661926582cd2e4160accf4991e859c4705/my_timer.py\"\n",
-    "timer = stackclub.wimport(timer_url, vb=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "help(timer)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "timer.func_timer(np.sin, np.pi/2.0)"
    ]
   },
   {
@@ -227,9 +274,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Importing code from Jupyter notebook HelloWorld.ipynb\n"
+     ]
+    }
+   ],
    "source": [
     "import stackclub\n",
     "import HelloWorld as Yo"
@@ -237,9 +292,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello World I'm using code imported from a notebook!\n"
+     ]
+    }
+   ],
    "source": [
     "Yo.take_that_first_baby_step(and_follow_up=\"I'm using code imported from a notebook!\")"
    ]
@@ -280,7 +343,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.6"
   },
   "livereveal": {
    "scroll": true,
@@ -288,5 +351,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/GettingStarted/ImportTricks.ipynb
+++ b/GettingStarted/ImportTricks.ipynb
@@ -38,17 +38,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/home/kadrlica/notebooks/StackClub/GettingStarted\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! cd .. && python setup.py -q develop --user && cd -"
    ]
@@ -62,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,18 +75,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "nb-kadrlica-r20-0-0\n",
-      "lsst_distrib          20.0.0     \tcurrent v20_0_0 setup\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# What version of the Stack am I using?\n",
     "! echo $HOSTNAME\n",
@@ -114,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "-"
@@ -156,17 +139,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Imported external module 'where_is' (downloaded from https://github.com/LSSTScienceCollaborations/StackClub/raw/master/stackclub/where_is.py and stored in .downloads/where_is.py)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "where_is_url = \"https://github.com/LSSTScienceCollaborations/StackClub/raw/master/stackclub/where_is.py\"\n",
     "so = stackclub.wimport(where_is_url, vb=True)"
@@ -174,17 +149,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<module 'where_is' from '.downloads/where_is.py'>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(so)"
    ]
@@ -198,22 +165,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'module' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-9-a8208c20fb3b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mlsst\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdaf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpersistence\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mButler\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mso\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwhere_is\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mButler\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0min_the\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'source'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/notebooks/StackClub/GettingStarted/.downloads/where_is.py\u001b[0m in \u001b[0;36mwhere_is\u001b[0;34m(object, in_the, assuming_its_a)\u001b[0m\n\u001b[1;32m     35\u001b[0m             \u001b[0mmodulename\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'lsst.pipe.tasks.'\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0mobjectname\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 37\u001b[0;31m     \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobject\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmodule\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     38\u001b[0m         \u001b[0;31m# Locate the module that contains the desired object, and break its name into pieces:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     39\u001b[0m         \u001b[0mmodulename\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mobject\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__module__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'module' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from lsst.daf.persistence import Butler\n",
     "so.where_is(Butler.get, in_the='source')"
@@ -221,29 +175,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nO2de5Ald3XfP2fuvHZmdndmZ2ffT2ARCAlWeCSQwRhLAovEJZEEO5LLseyC0j8mcULZQYQqcLCpwklVoJIiTlRCthwTBMGm2MSyZSGEsY0ltBJ6v3bZlbQ7+5jRvmZmd3Ze9+SP7rt79+59968fv9vnUzU19/bt7nv6dv/O93d+5/cQVcUwDMPIL11pG2AYhmGkiwmBYRhGzjEhMAzDyDkmBIZhGDnHhMAwDCPndKdtQDusXbtWd+zYkbYZhmEYXvHEE0+8oapjldu9FIIdO3awd+/etM0wDMPwChF5rdp2axoyDMPIOSYEhmEYOceEwDAMI+eYEBiGYeQcEwLDMIyc40QIROReEZkUkedqfC4i8l9FZL+IPCMi7y777A4R2Rf+3eHCHsMwDKN5XEUEfwLcXOfzjwC7wr87gT8CEJE1wOeB9wDXAZ8XkRFHNhmGYRhN4EQIVPWHwMk6u9wK/KkGPAoMi8hG4BeBh1T1pKqeAh6ivqAYhmEYjklqQNlm4FDZ+8PhtlrbL0NE7iSIJti2bVs8VkZlbg5++lOYnYWREXjzm6HbjzF78/Nw6hTMzMC5c8H7paXgs64u6O2FgQFYuRKGh2FwMF17m0YVDh+GI0eCe7FzJ6xZk7ZVxtmzsH9/UGbWrg3uS6GQtlW5xQ8vBajq3cDdAOPj49lbTefUKXjsMVhcDN5PTcHEBPzsz0J/f7q21eDMmcA/Hj8eCEAr9PXB+vWwcSOMjYFIPDZGoliEJ5+Eo0cvbjtyBK6+GmyKkvSYmoLHH4fl5YvvjxyB9743qHEYiZOUEEwAW8vebwm3TQAfrNj+g4RscsfcHPz4xxdFoMTZs4E4vP/9mantFItBBfngQZiebv888/Pw+uvBX18fbN8e+Na+PmemRuf55y8VgRLPPhuI84YNyduUd2ZmLhWBEmfOwN69cP31Ga1VdDZJdR/dA/x62HvovcAZVT0KPAh8WERGwiTxh8NtfvHUU7CwUP2z6Wl46aVk7alCsQivvgoPPwxPPx1NBCqZn4dXXoHvfS/wvbV+ikSZnAwuuBZPPx0YbiRHKUKrFIESJ04ETatG4jiJCETkGwQ1+7UicpigJ1APgKr+D+AB4J8A+4FzwG+Gn50Ukd8HHg9P9QVVrZd0zh4TE/DGG/X3OXgQtm0LGthTYHISnnsuCFDipFiEAweCKOGKK4Jm31Qqd8ViUOuvx8JCINDvelcyNhmBMDeqgbzyCmzZktnm1E7FiRCo6u0NPlfgt2p8di9wrws7EqdYbK62rxrsd+218dtUxsJCIAATE4l+LUtLQWRw6BDs3g2rVyf7/bz2WpDxbsShQ0FCf2gofpvyztIS7NvXeL/l5UAM3vnO+G0yLmAji6Nw5EhzDgfg2DG37TENmJyEH/wgeREoZ3oa/u7vgvKvSaX3i8WgN0ozqDbnnIzovPZa822Ghw7B+fPx2mNcgglBFFptz0yg/VMVXnwxyFFnoQm8FAw99lhCuYMjR1pzIhMT5nTiptRm2Mr+Bw/GZ49xGSYE7XLyZOs1/CNHYvWGCwvw6KPNV4iTZGoKfvjDoHNIrLTqQFSD2qoRH8ePty62r70WCIKRCCYE7dKO8ygWg7A3Bs6ehb//+8Z56zSZm4N/+IeglSwWpqfh9OnWj3v99QTbrnJIO2VlcbF6118jFkwI2mFpqf2HNAYhOH06EIG4ewW5YHk56C4eSyW83d/2/PlsK6jPzM0F4WA7xFRpMi7HhKAdjh6t3Re6ETMzTpPGb7wBP/pRRvruN4kqPPOM4zytarTM+OHD7mwxLhLlnkxNWf4mIUwI2iFqVxxHXXkmJ4MkbLualDYvveRwrN2JE9Gy41HE3ahN1Gf9yBE3dhh1MSFolcXF6M0IDto+S9O1+J5P27fPkRhEdRjLy4GyGu44ezZ69GtCkAgmBK1y7Fj0xGLEAnLiRDC1ke8iUGLfvojNRKpuMtCxZbFziotk76lT1jyUACYEreLKWbR5njNnOksESrz0Uv2pgepy6pSbQRPHj3feD5smrsrK8eNuzmPUxISgFYrF9ntAVNJGISlNZlpaJ6DTePbZNiuRrhzF4mIgKkZ0SgtcuMCEIHZMCFrhxAl3CcUzZ1qqxS4sZGe0cJw8+WQwVq8lXDoKczpucJlvmZqyRH7MmBC0gmsn0WRhKRaDxLAP4wSiUrrWZqdwYm6u9VV16mEJYze4/B2LxaASZsSGCUEruGoWavF8zzzTRi3ZYxYWgjxIU01gru/JzEwgLkb7qLq/LybQsWJC0Cxzc8FaxC6ZmmrYA+nAgXwOsJyZCZqJGnbQcu1w4jpnnjhz5vLV+qJiI79jxYSgWeJwDgsLdbuRvvEGvPCC+6/1hePHg6npa6Iaj4MwpxONOMrKzIx1I40RJ0IgIjeLyMsisl9E7qry+ZdF5Knw7xUROV322XLZZ3tc2BMLcTmHGuc9fx6eeMLmQnvllTqpmenpeObWMCGIRsJlxYhOZCEQkQLwVeAjwJXA7SJyZfk+qvrvVHW3qu4G/hvwF2Ufz5U+U9VbotoTGwk+3MViIAI+zR8UJz/5SY3kcVwJxPl5twnoPFEsxpfQMiGIDRcRwXXAflU9oKoLwP3ArXX2vx34hoPvTY7Z2fj6bZ48eVm1/6WX8pUcbsTiYiCMl431itMxWC+V9jh1Kr5BeSYEseFCCDYD5enMw+G2yxCR7cBO4Ptlm/tFZK+IPCoiH631JSJyZ7jf3qmkk3lxOoWlpUtWa5mcTGQhM+84fbpiTiLVeNXShKA94vzd5uasR1dMJJ0svg34tqqWjw7ZrqrjwK8CXxGRN1c7UFXvVtVxVR0fGxtLwtaLxO0UwvPPzwfNIEZ1fvrTsl6EMzPue6aUY0LQHnGHsnZfYsGFEEwAW8vebwm3VeM2KpqFVHUi/H8A+AFwjQOb3BL3w33yJKqBCFheoD5PPRW20sXtEObn8zGCzyVx5gdKWJtpLLgQgseBXSKyU0R6CZz9Zb1/RORtwAjwj2XbRkSkL3y9FngfkK0Ok0mEoydOcPCgdV9vhvl5ePppknEI5nRaY3o6/qkgLCKIhchCoKpLwCeBB4EXgW+p6vMi8gURKe8FdBtwv+olmdG3A3tF5GngEeBLqpotIUjAGcxNL/LKk44Hq3Uwx4/D5EsJOGlzOq2RhHDOzlrYHAPdLk6iqg8AD1Rs+1zF+9+rctyPgKtd2BAbMc9GWSwGo4e7151kcWwo1u/qFLrm53j9lfOsvhr6+mL8IpuJtDWS+r1OnYL165P5rpxgI4sbEXMt5+jRoCm6Z9acTrP0zp68IKCxDribnY03Id1pJNWUZgLtHBOCeiwvO11ovpJz5y6uxGdC0Dyl32pmBo7HPReZ5QmaY24uuSkgTAicY0JQj9OnY6tyql5ao+2em0GWrPbZDOWiefhQzGs0nD7deB8jWed86pTNveIYE4J6xPhwHz16+bQJPWfN6TSkWKT73HT5Ww4ejPH7rPbZHEn+TsvLNgWIY0wI6hFTbfD8eZioMtLChKAxPefOIHrpFAbT0zF2vY0xKuwoko6cLFJziglBPWKq5bz6anXfYnmCxnTPVncAr78eU153cdEGljWiWEzeMVuk5hQTglqcPx9L8mtqqnb+2SKCxvSere4AlpcDMYgFq33WZ3Y2vonmamH3xCkmBLWI4UFbXKy/2ljX4jxd8zapVj1qRQQQjP8qm7/PHeZ06pNG7Xxmxha0d4gJQS1iKPyHDjVeh9eigtrI0iLd8/WbaV59NYbKqQlBfdL4fVRjUv18YkJQC8cP2cxMc9Op95yzh7sWzfw28/NBjyynnDljCeN6pOWQTaCdYUJQC4cPmSq89lpz+9Zr+sg7zf42R444HltQLFp3xVoUi7EOuqyLRQTOMCGoxtyc04mtjh+vsdRiFaxpqDbNRkutCG/TmNOpzvR0etGSRQTOMCGohsNCv7hYfcxALbqWFynMN6kaOaP7bPP35fRpOOXST5jTqU6aAjk72zjpZjSFCUE1HBb6Q4da79zQisPLC80kiit5/TWHiWOLCKqTtkCm1SzVYZgQVMNRoZ+dbW+9bUsYX075tBLNMj8Px445MiDNJpAsk7ZApv39HYIJQTUcPFyq7Q9wsojgctoVxyNHHKV7lpcDZTcukoUkugmBE5wIgYjcLCIvi8h+Ebmryue/ISJTIvJU+PeJss/uEJF94d8dLuyJxPy8ky4nJ0607zcsIricdsWxWKw/iK8lzOlcShojiiuxe+KEyCuUiUgB+CrwIeAw8LiI7Kmy5OQ3VfWTFceuAT4PjAMKPBEem95EIg4erOXlaM6na3GersV5ij1xLr/lF1HE8cSJYEGroagLwFl79KVkwQnPzARi1GWNG1Fw8etdB+xX1QOqugDcD9za5LG/CDykqidD5/8QcLMDm9rHwcN99Gj0CdCseaiM5WUK56M1yziZhygLji9LZEEYVdNvnuoAXAjBZqC8/ns43FbJvxCRZ0Tk2yKytcVjEZE7RWSviOydim3OYSI/3AsLbhKU7SRHO5XuuRkkYqJ2dtbBWvQmBJeSld8jC4LkOUnFU/8X2KGq7ySo9d/X6glU9W5VHVfV8bGxMecGXiDiw33okJtmU8sTXKRnzk1BP3w44r1ZXAwGGxoBWXHAWREkj3EhBBPA1rL3W8JtF1DVE6paysDeA/xMs8cmyvJypLnnz551UOsMsYjgIq6ayebng1HekciK80ubc+diWgCiDeyeRMaFEDwO7BKRnSLSC9wG7CnfQUQ2lr29BXgxfP0g8GERGRGREeDD4bZ0iPhAOeudAhTmz9o0uyEuRfHIkYj+y5xOQJZ+hyzZ4imRew2p6pKIfJLAgReAe1X1eRH5ArBXVfcA/0ZEbgGWgJPAb4THnhSR3ycQE4AvqOrJqDa1TYQH6tRpt8+jqNI9N8PS0LC7k/qIqrOmIQi09chR2L6tzRNYM0RAlpxvqcluxYq0LfGWyEIAoKoPAA9UbPtc2evPAJ+pcey9wL0u7IhMmw+3Khx2GA2U6Jmbzr0QFBbmkGW388lMHocN66Gvnd65WXKAaZK13+HMGROCCFjn23LafLjfeCOeHKLlCeL5DVSDxHFbnLUmOyB7QpA1ezzDhKCcNh6m5eUITqUBNpYgPjE8cSJCv4C8O52lpUidKmLBxhJEwoSgxLlzbU1pe/x4fJ0nuufs4Y4zKmo7uZ93p5PF68+7OEfEhKBEGw/S0lIMyyKW0bW8mPvF7OMUgunpNnO/eXc6Wbx+a7KLhAlBiTZqOUePxv/s5TpPsLzc8hoErdJWVJBFR5gkWYwIbKqJSJgQlGixcLuaSqIRLrtO+kYSTWPnzsHJVjss510Isnr9JgRtY0JQosWHe2IimXVK8pwnSEoEDx1q8V4uLsL587HZk3myKgRZtcsDTAggmICmhV4Q58/DVBsrj7VDnpuGCgmJ4Px8GyvJ5bX2ef58dqaWqMSEoG1MCCCYmrKFKuHEBMHqCQlQOJ+BxT9Sovtccs52YqLFnzmvTifL151XcXaACQG09HCfO+duYrlmEFW6I87F7ytJ5kcWFmBysoUD8up0snzd8/OO1iXNHyYE0NLDfTiFuVHzmCeQxQW6FqMvGdoKLfUCy3LNOE6yLASQ3/sSERMCaPrhmZ2F0yksoplHIUjjmhcXW5imemYmmd4CWSPrjjbrQpVRTAig6YcnrqkkGpFU0jRLpJUkP3q0yQHmxWLQTpgnVIPaUJYxIWgLE4KlpaZmjJuZSa8y1JPDnkNpRUHLyy2MD8mb0zl3Lvujd/N2TxxhQpDxaACgMO9BAXRMms1hx483GRVkvZnENT442bzdE0c4EQIRuVlEXhaR/SJyV5XPPyUiL4SL1z8sItvLPlsWkafCvz2Vx8ZOEw/39HT6ZSBveYI0r7fpqCDthyJpfLjeJiN841IiC4GIFICvAh8BrgRuF5ErK3b7CTAeLl7/beA/lX02p6q7w79botrTMk083GlGAyXyJARdC+fpWk530NKxY02Mm/LBMbrEl+v1xc4M4SIiuA7Yr6oHVHUBuB+4tXwHVX1EVUuZtUcJFqnPBg1CyTNnspEfy5MQZOFai8UmZpadzdlgP1+aXUwIWsaFEGwGyudwPBxuq8XHgb8qe98vIntF5FER+Witg0TkznC/vVNTU9EsLqfBQzORwriBamTBOSZFVqbVmJxsEBWoZm+BlrhocRqWVDEhaJlEk8Ui8mvAOPCfyzZvV9Vx4FeBr4jIm6sdq6p3q+q4qo6PjY25MWhxMRiNWIPTp7MRDUDOhCAj11osBgvd1yUvTufcOX+in7zcE4e4EIIJYGvZ+y3htksQkZuAzwK3qOoF76uqE+H/A8APgGsc2NQcnkQDEM8i7lklK0IAwUL3dWctyIvT8ek68zrYLwIuhOBxYJeI7BSRXuA24JLePyJyDfA/CURgsmz7iIj0ha/XAu8DXnBgU3PUebhPnc5eJJwlBxknWZpbSRWO1utB5JODjIJP17m8bD2HWiSyEKjqEvBJ4EHgReBbqvq8iHxBREq9gP4zMAT8n4puom8H9orI08AjwJdUNRNCMJGBnkKVFOay4yDjoms+e5FP3ajAJwcZBd+u0zd7U6bbxUlU9QHggYptnyt7fVON434EXO3Chrao8bCcOp3N2QPyEBFk8RpLUcH2bVU+PHs2aDvv6vCxmb451tlZWL8+bSu8ocOf3gbUeLizGA1ANp2ka7J6jTWjgjz0HPKpx1AJ34QrZfIrBAsLVXsMZTUagOw6SZdk9Rrr5go63emUoh6f6PR74pj8CkGNfqFHMtRTqJI89BzKqhBAnaig052Oj9dnPYdaIr9CUOXhzmJPoUqy7ChdkKUeQ5XUjAp8dJStkJXBNK2wvBysr2w0hQlBGVmOBkp0cs+hLPYYqmTyeJXRxj46ylbwVeh8tTsFTAhCTnsQDUBnRwRZjgZKqFaZg6jT5xzy1aH6ancK5FcIKmpxR46kZEeLdLQQeHJtl81B1Mk9h3y+NhOCpsmnECwuXtJ+mJUZRpvBF2fZDr5cW7FYZb0CXx6gVvGxx1CJTr0nMZBPIaioKWRpTqFGdHLPIV+EAIJVzC6JCjq19unzdflse8LkUwjKagrT0/5VHDo1YezTdRWLgRhcoFOdjm+Fo5ylJes51CT5FIKyQutTNFDCh6Rqq2RhVbJWuWRtY58dZj18Fzjf7U+IXAvBzIyfz4lPTSjN4qO4XbK28exsZw5g8rGAlOO7/QmRTyEIa28+RgMABQ+dZiMK5/wssBeigmIxu3OTtIuq/5GOCUFT5E8IlpZgbo7ZWX+WYK2k21OnWQ9fo5zl5bJcQac5HZ9WJauF70KWEPkTAs+jAYDCwrnAA3UQPjYNlTh2LLwdnSYEneBEO+2exET+hGBmhtnZYOyAr4gq3fOeDvKpga8RAZRFBZ3gOMvpBCdaMWbIqI4TIRCRm0XkZRHZLyJ3Vfm8T0S+GX7+mIjsKPvsM+H2l0XkF13YU5eZGW9GEdfDZ8dZiSwu0LVUb2Hg7HPsGCyf7px7AnSGEEDnCXQMRBYCESkAXwU+AlwJ3C4iV1bs9nHglKq+Bfgy8IfhsVcSrHH8DuBm4L+H54uN2WOznD4d5zckQycJQSdcy9ISTB7osJ5DneJAO0XQYsRFRHAdsF9VD6jqAnA/cGvFPrcC94Wvvw3cKCISbr9fVedV9SCwPzxfbEy81BkPhU+DrxrRCUIAcGximeXZDlo0vVMcaKcIWoy4WLN4M3Co7P1h4D219lHVJRE5A4yG2x+tOHZztS8RkTuBOwG2bau2eGxz7Pz1n2v72Eyhivztg2lb4QS98SoYi79VMAkOf+95pp6fTNuMyBT7VnD6bTeBpG1JdLr2zzO8pzPKyttu283Qm92vxexk8fokUNW7gbsBxsfH246/e4d6ndmUKsUiyJL/3fsAVvZBh9yXDdv7mHxywfsWovne1cxrZ9yTLlWK5/3OQQGsXg1D6wZiObeLpqEJYGvZ+y3htqr7iEg3sBo40eSxRjW6umAgnocicYaG0rbAGX1rV7J2bdpWRGdpYGXaJjij2NNHsdt/Udu8RWBwMJZzuxCCx4FdIrJTRHoJkr97KvbZA9wRvv4Y8H1V1XD7bWGvop3ALuDHDmzKBys7oLD29EB/f9pWuGNoiE2bQDxvUlle0QHPVhlL/X5XNlatgqH1g0EFMAYin1VVl4BPAg8CLwLfUtXnReQLInJLuNvXgFER2Q98CrgrPPZ54FvAC8BfA7+lqp01UipOOkEIOigaAGDlSvr68D4q8N1xVrLkubBt3kysZcVJjkBVHwAeqNj2ubLX54FfrnHsF4EvurAjd3SCE+0EMSunuxv6+9m06TxTbwCe5gp8d5yVLK/wt6ysXBkWkxjLSv5GFncSneBEO+EaKilFBaNpG9IexZ4+tLsnbTOc4rOwbS71ozQhMKoyNOR/Y3QnRDWVhAV20ya87H7ps9Osha/XNDQU5AcuvIkJEwKf6YSeQ50YEYQFtr8fRtekbEsb+Oo061Hs7UcL3vSWv8CFaEDEhMCog8+OtLsbVqxI2wr3lN0TH6OCThQC8O+6hoaCsQNAUE4K8c2+Y0LgOz4LQSc2C8El92TFClgzkqItbdBpPYZK+HZdmzaVvYm5nJsQ+I7PztRnEatHTw/09V14u6nqpCnZxbeac7P4dF2DgzA8XLbBhMCoi8/O1GcRa0TZfRlYASOeRAXF7l60x/9RuNXwSQguqzzEXFZMCHzH555DPotYIyqubbMnUYFPzrJVfLm2gQEYGa7YaBGBUZdCwd+EaycLQUUNbmAAhj2ICnxxlu1Q7FvhRc+hqpUGiwiMhvjoUAsF/7u+1qPKPdm8qcp+GaOThQCynzAeGKjSjLhiRdDDLkZMCDoBH4Wgk/MDUPWeDA5mPyrweSqGZsi60FWNBhIo3yYEnYCPQuCjza3Q2xv8VZD1qCDrjjIqWb6+qtEAmBAYTeKjU/XR5lbxLCoodvdS7OlrvKPHZLlpaFOtSoIJgdEUPjaz5FQIILtRQZZry65YzuiCOwMDsKbWdCQmBEZT+Jh4zbEQXDZYKCNkubbsiuW+AbQrvqka2qVmNACJVPRMCDoFnxyrj8LVDnXuSRbHFeQhIoDsXWfdaCCBHkMQUQhEZI2IPCQi+8L/l7V+ishuEflHEXleRJ4RkX9Z9tmfiMhBEXkq/NsdxZ5c45MQ+NiU1Q517kkWcwVZbTZxTdaEoG40kFC5jhoR3AU8rKq7gIfD95WcA35dVd8B3Ax8RUTKA+PfVdXd4d9TEe3JLz4JgU+2RqG395I5hyrJWq4gaw4yLrJ0nXWjAfBGCG4F7gtf3wd8tHIHVX1FVfeFr48Ak8BYxO81KvHJufpka1Q8iQry0GOoRJaEoGEToSdCsF5Vj4avjwHr6+0sItcBvcBPyzZ/MWwy+rKI1HwSReROEdkrInunpqYimt2B+DTnkAnBBbZkJFeQJecYN1m51prjBsrJihCIyPdE5Lkqf7eW76eqSp2lukVkI/C/gN9U1WK4+TPA24BrgTXAp2sdr6p3q+q4qo6PjVlAcRk+JWAvrL2XAxoU5IZNAwmRFeeYBFmZc2jzliZ2SkgIGv4aqnpTrc9E5LiIbFTVo6Gjn6yx3yrgL4HPquqjZecuRRPzIvLHwO+0ZL1xKStXwtmzaVtRn05dlawWTRTkTZvh5CnqVKPiJ09CAMH19syeSu37BwerzDBaycBArKuSlRO1aWgPcEf4+g7gu5U7iEgv8B3gT1X12xWfbQz/C0F+4bmI9uQbH5pc8tJjqEQT92RgRfprG+dRCNJkS4aiAYguBF8CPiQi+4CbwveIyLiI3BPu8yvAB4DfqNJN9Osi8izwLLAW+IOI9uQbH4QgT81CEKxW1t/fcLfNm0l1beOlgXzdlzSF4JK1iOuRYFmJ1FCmqieAG6ts3wt8Inz9Z8Cf1Tj+hijfb1TggxD4YKNrVq6E8+fr7tLfD2tH4Y03ErKpjOWefrS7J/kvTpE0haCpaAC8igiMLOFDz6G8CkETbN6czu1Lu5kkDdK65lWrWqjomxAYbdHVlf02+DwKQZMlv68P0ugQt5STEcXlFHv7KXYnvzZz09GASKJl2YSg08iyo+3tbaq9vONo4Z5s2hToeZIsrchXfqBE0lHB8HALvn1wMNEHwYSg08hyMjbLIhUnK1c23ebT2wvr1sVsTwV5bBqC5K+76WgAEi/HJgSdRpadbZZFKk5aHOy3cWNi3cdRkfwKQYI9pUZHWxzvaUJgRCLLzjbLIhU3LVx7Tw9s2BCjLWUs9yY3aClrJCaA0sa04wmXFROCTmNgIJH5y9siyyIVNy1e+4YNydzGvI0fKCepax9b20ZqzCICIzJZrXln1a4kaLFgFwoN5ql3RF6bhQC00M1yb7zTnXR1tRENdHcnPm+YCUEnkkWHm+VIJQnauCfr1gXJ4zjJc0QA8V//+vVt3MMUyq8JQSeSxSaYLNqUJIODLbfFd3W12NOkDUwI4rv+QiFI/LeMCYHhhCw63SxGKUki0tZv0HJvkxbQrgLLfZ5MXR4TizGOodi0qc0gOIXya0LQiWRRCLJoU9K08RuIxBcVLK1ofnxDpxJXRNDbGzQLtUVTM9K5xYSgE2lyxstEMSFoOyoaHo7n58t7sxDAcv8g2uW+++zmzREGBlvTkOGMFGoVNSkUgjbyvBPhnmzd6tCOkDibRbwhhgF1AwOwdm2bB69YEVTkEsaEoFPJUg28hSkWOpoI92RwMMgXuGRpMEOVhRRxHRlt3RrhcU+pAhdJCERkjYg8JCL7wv9Vl2IWkeWyRWn2lG3fKSKPich+EflmuJqZ4YIsCUGWopM06emJtEznli1u9dSahgJcRkarVkV83FMqt1EjgruAh1V1F/Bw+L4ac6q6O/y7pWz7HwJfVtW3AKeAj0e0x6YNTEIAABCqSURBVCiRJeebJVFKmwi/RV+fu6knlvsGMrGAexZwFhkJbNse8RyeCsGtwH3h6/sI1h1uinCd4huA0jrGLR1vNCDBha8bYkJwkYgC3XaXxAoWLRq4gKvIaGxtsP50JDwVgvWqejR8fQyo1WGqX0T2isijIlJy9qPAaVVdCt8fBmoOxhaRO8Nz7J2amopodg4QyYYDFslWdJI2Ee9JodDGlAVVWBqwe1JCC92Rx1MUCg66+XZ3p9apomHdQkS+B1QLSD9b/kZVVUS0xmm2q+qEiLwJ+H64YP2ZVgxV1buBuwHGx8drfY9RzurVcOpUujZkKTLJAg5Ecd06mJyEubn2z2H5gUtZHFhNYf5c28dv3Oigs0+KFbeGQqCqN9X6TESOi8hGVT0qIhuByRrnmAj/HxCRHwDXAH8ODItIdxgVbAEm2rgGoxZZqIlnwYYsMTAQeIzFxbZPIQLbtsHLL7dvxqJFBJewNLgaTh1tvGMVnOVuUiwrUZuG9gB3hK/vAL5buYOIjIhIX/h6LfA+4AVVVeAR4GP1jjcikIWmIROCy3FwX1avDgaatUOxu5diX7yzbvpGlJ5DW7c6WlXSYyH4EvAhEdkH3BS+R0TGReSecJ+3A3tF5GkCx/8lVX0h/OzTwKdEZD9BzuBrEe0xylm1Kv3++yYEl+PoN9m2rb3ba9HA5bTbc2jVKlizxpERKZaVSP0PVPUEcGOV7XuBT4SvfwRcXeP4A8B1UWww6tDVFQzmmp5OzwYTgstptypfQX9/0CRxtMUWDRtIdjnF3n6KPX10Lc43f5CL7qIlSmU1JWxkcafjyOm0xYoV8U+o7yMOxXHTptaTlBYRVKfV32X9OgfdRUukHL2bEHQ6adbILRqoThtrE9SiUAiaiFrBIoLqtPK79PS46cZ7gZTLiglBp5PmA5ZmNJJlHI+tGB1tPv9cLPSw3G8TAFZjcbD553XLFscL7qVcVkwIOp3Vq9MLOS0iqI3jgr99e3O32aKB2jQrBENDMDbm+MstIjBiJc0klEUEtXFc8FesaK4veyu13rxRShjXRWDHDsdfnHKiGEwI8kEaDtkSxfWJ4Z5s2hQMbqqHCUF9Gv0+G9bHsHTo6tWOBiK0jwlBHkhDCEaqzkhulBgactzIHCaOG3RnNCGoT73fp7fXcYK4RAYiZxOCPJDGg5aBhzvzxPAbjQzXHuBU7OmzEcUNqCcEO3bENG1WBsqKCUEeWLUq+YnfMvBwZ56Yoqbt26vfbosGGrM4VP2erFkT4yOdgbJiQpAHkp4KWiQTD3fmiek36umpPraglpMzLqLdPSz1Xdq9tlAIxDUWenqCZsKUMSHIC0k65pUrberpZogxjzI2dvnYAosImqNSMLdvj3E9+YxUmEwI8kKSyVtLFDdHX1+kNYwbsXPnpXpsQtAc5UKwejWsXRvjl2WkrJgQ5AVnUyQ2QUYebi+I8b709V1cNWtpxUq0O65qbWdREoJCIRDTWMlIWTEhyAv9/bHWPi8hSdHxnZgdwfr1QROR5QeaZ2lgFdpVYPv2BIbCmBAYiZPEQ9fXl9q6q16SgGju3Ak6YuLcNCKs3DYSb5MQBLm02JIPrWFCkCeSqKlnpIbjDatWOR9YVklfH7z1vSYEzdLXB2+5NoHnOEORcyQhEJE1IvKQiOwL/1/264nIL4jIU2V/50Xko+FnfyIiB8s+2x3FHqMBSTx4GXq4vUAkfvHs62PTrsF4RsV2ILt3Q+/G0fi/KENlJWpEcBfwsKruAh4O31+Cqj6iqrtVdTdwA3AO+JuyXX639LmqPhXRHqMeCdQ+s/Rwe0Pcv1l4/quvTi5N5Cs7d8K6dQTiHPesvRkqK1GF4FbgvvD1fcBHG+z/MeCvVPVcxO812kEk3oevUMhMv2iviNshjAa1254eePe701/GOqusWgVXXhm+6e5ufpGHdlixIobZ69onqhCsV9XSiqnHgPUN9r8N+EbFti+KyDMi8mURqTl3oojcKSJ7RWTv1NRUBJNzzmiMIe+aNeZl2mFkJN7ZJ8vu+Zo1cMUV8X2Vr3R3w8/8TMVtiLOsxHnuNmj49InI90TkuSp/t5bvp6oKaJ3zbCRYxP7Bss2fAd4GXAusAT5d63hVvVtVx1V1fMz5qhA5Is6uEBl7uL2hUIgvT9Dbe1nNdteusPnDuMA731llpocclZWGDcaqelOtz0TkuIhsVNWjoaOfrHOqXwG+o6qLZecuRRPzIvLHwO80abfRLqtXB9WfpSX35469v10HMzoKJ07Ec94qXHMN/PCHMDfn/it9Y/v2GtNLlyJcrVm/bZ+MlZWo8ege4I7w9R3Ad+vsezsVzUKheCAiQpBfeC6iPUYjROKpjXR3W34gCnE5hhrn7e2F8fHU10NJnZERuOqqGh/29MQzWePAQKbyAxBdCL4EfEhE9gE3he8RkXERuae0k4jsALYCf1tx/NdF5FngWWAt8AcR7TGaIY6mtdFRyw9EYWQknon66tzr4eGgSSSv9PU1IYZxlJWMRQPQRNNQPVT1BHBjle17gU+UvX8VuCz4UtUbony/0SZxPNyWt4lGV1fgII4fd3fOFSsajvLeuhXOnIGDB919rQ90dcG11wYzr9RlbAz27XP75RksKzkPDHPK0JD7DuWWfYyOawfR5D15xzvyd/ve9a4m8/MjI27H3oiYEBgZwmXJHxy0+YVc4NobN3k+kaDrZJzd5rPEW996cVbWhpQiNVeMjGRmfqFyTAjyikunk7fqZFy4FNQWHVh3N7znPU00lXjOli1tjKNY32h4VAtktKyYEOSVsTF3yUmXBSXvuPotR0dbbtLo74f3vjeTFVYnrFsXzCPU1oGuyGhZMSHIK4WCm5C3pydzg2O8ZuNGN+fZsKGtw1auDCKDuKekSpo1a4IeQm11bOvvd9M1emAgs+1vJgR5xoXTWb/eOqO7ZGQk6NcYlTaFoGTCddd1zrLTw8OBuEW6HhdlxZXIx4CV4DyzYUN0J57hh9tLRKL/pmvWRG7sHx3tDDEYHg6auyJHOCYERsfS0xOtK1tPT2aTX16zaVO6x4esXet3M9GaNXD99Y5yHoOD0ZqHBgYyvWiTCUHeabofXRU2brRmoTgYHW1/nEdXV42Jc9o35frrE1i71zHr1jmKBMqJ8rtmfFUgK8V5Z8OG9qtMW7e6tcW4SLsCvW6dc689PAzvf78/Q0W2bYupWWvLlvYrPhkvKyYEeaerqz2nMzSUqRWWOo5t29rr4rJtm3tbCETg534uk9PkXEAkWFjmXe+Kadqr3t72kvCjo5lXURMCA3bsSOYYo3kGBlrPv7RzTAv09ATNLW96U2xf0Ta9vUE+481vjvmLOrSsmBAYQe2+FQfS0xNbzdMoo1WP+6Y3xT4DrEgwN9G112YnbzA6Cj//8wlN4TM62trU1AMDme4tVMKEwAjYtav5fd/0Jv/7FfrA2rXN9zTp60tUnDdsgA9+MNJwhcgUCoEoXX99wlNjvPWtze/7lrd4MT27CYERsGZNc8Pf+/qy2TbQqbz97c3tt2tX4uLc1xdEBuPj7iezbcS6dYEQJRAEXc6GDc11JR0czHySuIQJgXGRd7yjca+It7/d347lPjI62nhcwKpVqbZDb9wIv/AL8La3xT9P0erVQZ7iPe9JeZGvq69urEBXXeVN9+pIVorIL4vI8yJSFJHxOvvdLCIvi8h+EbmrbPtOEXks3P5NEclIq2NOGRwMul3UYsMGb2o4HcXVV9du+ygUggWIU25+KBSCoOSmm4JHyHWEUBrc9oEPZGQ6/+HhoNmnFtu2eTXYMqpcPQf8c+CHtXYQkQLwVeAjwJXA7SJS8jZ/CHxZVd8CnAI+HtEeIyo7dwZ/lQwPBw7HSJ7e3qBjfGV1u6sL3v3uTE1k1t0d9Ny58cbAcW/d2n5SeeXKoDn+hhuCPEDm/OoVV1SP1sbGAvH2iKhLVb4IIPVrI9cB+1X1QLjv/cCtIvIicAPwq+F+9wG/B/xRFJsMB1x1VRCDHzgAS0vBw/7Wt1qCOE1Wrw6qwy++CCdPBl7yiisyO22BSOC4160DVZieDsyenoZz5+D8+eDRKhaDx6qnJ4gihoaCSx0d9WBtBJFAiEdG4PXXg4vZujVQQk+ahEok0di7GThU9v4w8B5gFDitqktl22uOwxaRO4E7AbZZ18X42brVmoGyxsBAsJSYZ4gEzr2VXpfeIBJkrD3vQNFQCETke0C1TmKfVdXvujepOqp6N3A3wPj4uCb1vYZhGJ1OQyFQ1ZsifscEUF613BJuOwEMi0h3GBWUthuGYRgJkkRD1uPArrCHUC9wG7BHVRV4BPhYuN8dQGIRhmEYhhEQtfvoPxORw8D1wF+KyIPh9k0i8gBAWNv/JPAg8CLwLVV9PjzFp4FPich+gpzB16LYYxiGYbSOBBVzvxgfH9e9e/embYZhGIZXiMgTqnrZmC+/+jgZhmEYzjEhMAzDyDkmBIZhGDnHhMAwDCPneJksFpEp4LU2D18LvOHQnKTx3X7w/xp8tx/8vwbf7Yd0rmG7ql42bZ+XQhAFEdlbLWvuC77bD/5fg+/2g//X4Lv9kK1rsKYhwzCMnGNCYBiGkXPyKAR3p21ARHy3H/y/Bt/tB/+vwXf7IUPXkLscgWEYhnEpeYwIDMMwjDJMCAzDMHJOroRARG4WkZdFZL+I3JW2Pa0gIveKyKSIPJe2Le0gIltF5BEReUFEnheR307bplYRkX4R+bGIPB1ew39M26Z2EJGCiPxERP5f2ra0g4i8KiLPishTIuLd7JMiMiwi3xaRl0TkRRG5PnWb8pIjEJEC8ArwIYJlMR8HblfVF1I1rElE5APALPCnqnpV2va0iohsBDaq6pMishJ4AvioL78/gASLcw+q6qyI9AB/D/y2qj6asmktISKfAsaBVar6S2nb0yoi8iowrqpeDigTkfuAv1PVe8I1WgZU9XSaNuUpIrgO2K+qB1R1AbgfuDVlm5pGVX8InEzbjnZR1aOq+mT4eoZgbYqaa1RnEQ2YDd/2hH9e1aREZAvwT4F70rYlj4jIauADhGuvqOpC2iIA+RKCzcChsveH8cwRdQoisgO4BngsXUtaJ2xWeQqYBB5SVd+u4SvAvweKaRsSAQX+RkSeEJE70zamRXYCU8Afh81z94jIYNpG5UkIjAwgIkPAnwP/VlWn07anVVR1WVV3E6yxfZ2IeNNMJyK/BEyq6hNp2xKR96vqu4GPAL8VNpv6QjfwbuCPVPUa4CyQer4yT0IwAWwte78l3GYkRNiu/ufA11X1L9K2JwphOP8IcHPatrTA+4Bbwjb2+4EbROTP0jWpdVR1Ivw/CXyHoNnXFw4Dh8siyW8TCEOq5EkIHgd2icjOMEFzG7AnZZtyQ5ho/Rrwoqr+l7TtaQcRGROR4fD1CoKOBy+la1XzqOpnVHWLqu4geP6/r6q/lrJZLSEig2FnA8ImlQ8D3vSkU9VjwCERuSLcdCOQeoeJ7rQNSApVXRKRTwIPAgXgXlV9PmWzmkZEvgF8EFgrIoeBz6vq19K1qiXeB/wr4NmwjR3gP6jqAyna1CobgfvCHmhdwLdU1csumB6zHvhOUK+gG/jfqvrX6ZrUMv8a+HpYIT0A/GbK9uSn+6hhGIZRnTw1DRmGYRhVMCEwDMPIOSYEhmEYOceEwDAMI+eYEBiGYeQcEwLDMIycY0JgGIaRc/4/CpInenkzBnEAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Imported external module 'fill_demo_features' (downloaded from https://matplotlib.org/mpl_examples/lines_bars_and_markers/fill_demo_features.py and stored in .downloads/fill_demo_features.py)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mpl_url = \"https://matplotlib.org/mpl_examples/lines_bars_and_markers/fill_demo_features.py\"\n",
     "mpl = stackclub.wimport(mpl_url, vb=True)"
@@ -274,17 +208,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Importing code from Jupyter notebook HelloWorld.ipynb\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import stackclub\n",
     "import HelloWorld as Yo"
@@ -292,17 +218,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Hello World I'm using code imported from a notebook!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "Yo.take_that_first_baby_step(and_follow_up=\"I'm using code imported from a notebook!\")"
    ]

--- a/stackclub/where_is.py
+++ b/stackclub/where_is.py
@@ -34,13 +34,13 @@ def where_is(object, in_the='source', assuming_its_a=None):
         if assuming_its_a == "cmdlinetask":
             modulename = 'lsst.pipe.tasks.'+objectname
             
-    elif isinstance(object, module):
+    elif hasattr(object, '__module__') and hasattr(object, '__name__'):
         # Locate the module that contains the desired object, and break its name into pieces:
         modulename = object.__module__
         objectname = object.__name__
     
     else:
-        raise TypeError('Expecting objects of type "string" or "module"')
+        raise TypeError('Expecting "string" or "object"')
 
     # Form the URL, and a useful markdown representation of it:    
     if in_the == 'source':


### PR DESCRIPTION
* Update `where_is` function
* Updates to FindingDocs.ipynb and ImportTricks.ipynb notebooks.
* Replace a missing gist url with a url to a matplotlib example
* Closes #234 

Note that ImportTricks.ipynb is pulling `where_is` from master, so it will fail until this PR is merged.

This PR is ready for review.

