### PR TITLE
Update LowSurfaceBrightness for v20

### DIFF
--- a/SourceDetection/LowSurfaceBrightness.ipynb
+++ b/SourceDetection/LowSurfaceBrightness.ipynb
@@ -113,7 +113,7 @@
    "source": [
     "### Data access\n",
     "\n",
-    "Here we use the `butler` to access a `calexp` from a dataset in the RC repo. More information on the `butler` will be available in `Butler_Tutorial.ipynb` (TBD), while a deeper examination of the `calexp` object can be found in [Calexp_guided_tour.ipynb](https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/Calexp_guided_tour.ipynb). We expect the user to have a working knowledge of these objects."
+    "Here we use the `butler` to access a `calexp` from a dataset in the RC repo. More information on the `butler` is available in [`ButlerTutorial.ipynb`](https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/ButlerTutorial.ipynb), while a deeper examination of the `calexp` object can be found in [Calexp_guided_tour.ipynb](https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/Calexp_guided_tour.ipynb). We expect the user to have a working knowledge of these objects."
    ]
   },
   {

--- a/SourceDetection/LowSurfaceBrightness.ipynb
+++ b/SourceDetection/LowSurfaceBrightness.ipynb
@@ -7,21 +7,21 @@
     "# Low-Surface Brightness Source Detection\n",
     "\n",
     "<br>Owner: **Alex Drlica-Wagner** ([@kadrlica](https://github.com/LSSTScienceCollaborations/StackClub/issues/new?body=@kadrlica))\n",
-    "<br>Last Verified to Run: **2019-07-21**\n",
-    "<br>Verified Stack Release: **v18.0.0**\n",
+    "<br>Last Verified to Run: **2020-07-24**\n",
+    "<br>Verified Stack Release: **v20.0.0**\n",
     "\n",
-    "This Notebook demonstrates how to run the source detection, measurment, and deblending algorithms with a focus on optimizing for low-surface brightness object detection. It attempts to split out the source detection and measurement algorithms from `processCCD` and apply them to the search for low surface brightness galaxies. The content of this notebook builds off of an analysis from Johnny Greco, adapted into notebook form in Robert Lupton's [Greco LSB.ipynb](https://github.com/RobertLuptonTheGood/notebooks/blob/master/Demos/Greco%20LSB.ipynb). Some source detection and measurement details come from [Tune Detection.ipynb](https://github.com/RobertLuptonTheGood/notebooks/blob/master/Demos/Tune%20Detection.ipynb) and [Kron.ipynb](https://github.com/RobertLuptonTheGood/notebooks/blob/master/Demos/Kron.ipynb).\n",
+    "This notebook demonstrates how to run the source detection, measurment, and deblending algorithms with a focus on optimizing for low-surface-brightness object detection. It attempts to split out the source detection and measurement algorithms from `processCCD` and apply them to the search for low-surface-brightness galaxies. This notebook was inspired by the analysis of [Greco et al. 2018](https://arxiv.org/abs/1709.04474), adapted into notebook form in Robert Lupton's [Greco LSB.ipynb](https://github.com/RobertLuptonTheGood/notebooks/blob/master/Demos/Greco%20LSB.ipynb). Some source detection and measurement details come from [Tune Detection.ipynb](https://github.com/RobertLuptonTheGood/notebooks/blob/master/Demos/Tune%20Detection.ipynb) and [Kron.ipynb](https://github.com/RobertLuptonTheGood/notebooks/blob/master/Demos/Kron.ipynb).\n",
     "Interaction with `lsst.afw.display` was also improved by studying Michael Wood-Vasey's [DC2_Postage Stamps.ipynb](https://github.com/LSSTDESC/DC2-analysis/blob/master/tutorials/dm_butler_postage_stamps.ipynb).\n",
     "\n",
     "### Learning Objectives:\n",
-    "After working through and studying this notebook you should be able to\n",
+    "After working through this notebook you should be able to\n",
     "   1. Run the `lsst.meas.algorithm` source detection, deblending, and measurement tasks.\n",
     "   2. Plot the resulting source catalogs and examine the mask of `DETECTED` pixels\n",
     "   3. Remove detected sources at pixel level using the detected `FootprintSet`\n",
     "   4. Re-run the source algorithms after convolving an image with a Gaussian kernel of a specific size.\n",
     "\n",
     "Other techniques that are demonstrated, but not empasized, in this notebook are\n",
-    "   1. Use the `butler` to access a specific `calexp` `Exposure` object from Twinkles.\n",
+    "   1. Use the (gen-2) `butler` to access a specific `calexp` `Exposure` object from the HSC RC dataset.\n",
     "   2. Create an image cutout and use `lsst.afw.display` to plot it.\n",
     "   3. Learn a bit about the [`matplotlib` backend to `lsst.afw.display` ](https://github.com/lsst/display_matplotlib/blob/master/python/lsst/display/matplotlib/matplotlib.py)\n",
     "\n",
@@ -29,7 +29,7 @@
     "This notebook is intended to be runnable on `lsst-lsp-stable.ncsa.illinois.edu` from a local git clone of https://github.com/LSSTScienceCollaborations/StackClub.\n",
     "\n",
     "\n",
-    "## Set Up"
+    "### Set Up"
    ]
   },
   {
@@ -72,9 +72,9 @@
     "import lsst.daf.base        as dafBase\n",
     "\n",
     "import lsst.afw.image       as afwImage\n",
-    "import lsst.afw.geom        as afwGeom\n",
     "import lsst.afw.display     as afwDisplay\n",
-    "import lsst.afw.table       as afwTable"
+    "import lsst.afw.table       as afwTable\n",
+    "import lsst.geom            as afwGeom"
    ]
   },
   {
@@ -84,8 +84,8 @@
    "outputs": [],
    "source": [
     "# Filter some warnings printed by v16.0 of the stack\n",
-    "warnings.simplefilter(\"ignore\", category=FutureWarning)\n",
-    "warnings.simplefilter(\"ignore\", category=UserWarning)\n",
+    "#warnings.simplefilter(\"ignore\", category=FutureWarning)\n",
+    "#warnings.simplefilter(\"ignore\", category=UserWarning)\n",
     "\n",
     "zscale = ZScaleInterval()\n",
     "plt.rcParams['figure.figsize'] = (8.0, 8.0)"
@@ -97,12 +97,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Position of our \"ultra-diffuse galaxy\"\n",
-    "x_target, y_target = 3835, 2380\n",
+    "# Position of our low surface brightness \"galaxy\"\n",
+    "x_target, y_target = 1700, 2100\n",
+    "width,height=400,400\n",
+    "xmin,ymin = x_target-width//2, y_target-height//2\n",
     "\n",
     "# Position of our cutout\n",
-    "xmin,ymin = 3550,2100\n",
-    "width,height=400,400"
+    "#x_target, y_target = 3835, 2380\n",
+    "#xmin,ymin = 3550,2100\n"
    ]
   },
   {
@@ -121,7 +123,7 @@
    "outputs": [],
    "source": [
     "# The dafPersist was trying to set the matplotlib backend, catch warning\n",
-    "datadir = \"/project/shared/data/Twinkles_subset/output_data_v2\"\n",
+    "datadir = '/datasets/hsc/repo/rerun/RC/v20_0_0_rc1/DM-25349'\n",
     "butler = dafPersist.Butler(datadir)"
    ]
   },
@@ -142,7 +144,7 @@
    "outputs": [],
    "source": [
     "# Grab a calexp of interest\n",
-    "dataId = {'filter': 'r', 'raft': '2,2', 'sensor': '1,1', 'visit': 235}\n",
+    "dataId = {'filter': 'HSC-Z', 'ccd': 32, 'visit': 38938}\n",
     "calexp = butler.get('calexp', **dataId)"
    ]
   },
@@ -190,10 +192,10 @@
    "source": [
     "Our next step is to generate a cutout image. This is done by creating a bounding box and passing it to the `Factory` method of our calexp (a `lsst.afw.image.Exposure` object). Unfortunately, the arguments for the `Factory` method are poorly documented, and below we explain the specific arguments that we are passing to `Factory`:\n",
     "```\n",
-    "calexp: the ExposureF we are starting from\n",
-    "bbox : the bounding box of the cutout\n",
+    "calexp : the ExposureF we are starting from\n",
+    "bbox   : the bounding box of the cutout\n",
     "origin : the image pixel origin is local to the cutout array\n",
-    "deep : copy the data rather than passing by reference\n",
+    "deep   : copy the data rather than passing by reference\n",
     "```"
    ]
   },
@@ -233,7 +235,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ok, even for us this may be a little faint. Let's add a few more photons to this source. We generate a list of additional photons from a 2D Gaussian and add them to the pixel values of the image array."
+    "Ok, we've found a \"blank\" patch of sky. Let's add a few more photons to create a galaxy. We generate a random set of photons from a 2D Gaussian and add them to the pixel values of the image array."
    ]
   },
   {
@@ -243,11 +245,12 @@
    "outputs": [],
    "source": [
     "# Generate a list of photons with random pixel coordinates drawn from a 2D Gaussian\n",
-    "nphotons = int(2e4) # 20k photons\n",
+    "nphotons = int(5e4) # 20k photons\n",
     "sigma = 250         # Gaussian sigma in pix\n",
     "cov = [[sigma,sigma/2],[sigma/2,sigma]] # covariance (give the source some ellipticity)\n",
+    "np.random.seed(42) # for repeatability\n",
     "xidx,yidx = np.random.multivariate_normal((x_target,y_target),cov,size=nphotons).astype(int).T\n",
-    "np.add.at(calexp.image.array, [yidx,xidx], 1)"
+    "np.add.at(calexp.image.array, (yidx,xidx), 1)"
    ]
   },
   {
@@ -369,6 +372,7 @@
     "psf = calexp.getPsf()\n",
     "sigma = psf.computeShape().getDeterminantRadius()\n",
     "pixelScale = calexp.getWcs().getPixelScale().asArcseconds()\n",
+    "# The factor of 2.355 converts from std to fwhm\n",
     "print('psf fwhm = {:.2f} arcsec'.format(sigma*pixelScale*2.355))"
    ]
   },
@@ -404,7 +408,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The source detection tasks returns an [`lsst.pipe.base.struct.Struct`](http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/classlsst_1_1pipe_1_1base_1_1struct_1_1_struct.html). A `Struct` is just a generalized container for storing multiple output components and accessessing them as attributes. The content of this `Struct` can be investigated with the `getDict` method."
+    "The source detection task returns an [`lsst.pipe.base.struct.Struct`](http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/classlsst_1_1pipe_1_1base_1_1struct_1_1_struct.html). A `Struct` is just a generalized container for storing multiple output components and accessessing them as attributes. The content of this `Struct` can be investigated with the `getDict` method."
    ]
   },
   {
@@ -476,7 +480,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get a better look at the output sources, we need to make sure that the `SourceCatalog` is contiguous in memory. Converting to an `astropy` table provides a human-readable output format. A deeper dive into `SourceCatalog`s is beyond the scope of this notebook."
+    "To get a better look at the output sources, we need to make sure that the `SourceCatalog` is contiguous in memory. Converting to an `astropy` table provides a human-readable output format. A deeper dive into `SourceCatalog` is beyond the scope of this notebook."
    ]
   },
   {
@@ -543,7 +547,7 @@
    "source": [
     "### Faint Source Detection\n",
     "\n",
-    "Our goal now is to improve the detection of faint, low-surface brightness sources in our images. Our plan of attack is to subtract the bright sources that have already been detected, and then convlve the residual image with a large spatial kernel. Our hope is that this will increase the contrast for our faint target.\n",
+    "Our goal now is to improve the detection of faint, low-surface brightness sources in our images. Our plan of attack is to subtract the bright sources that have already been detected, and then convolve the residual image with a large spatial kernel. Our hope is that this will increase the contrast for our faint target.\n",
     "\n",
     "We start by identifying the pixels that are associated with the sources that we detected. This information is contained in the mask plane of our calexp and can be visualized with the `MaskedImage` object. "
    ]
@@ -758,7 +762,7 @@
     "        afw_display.dot('+', *s.getCentroid(), ctype=afwDisplay.RED)\n",
     "        afw_display.dot('o', s.getX(), s.getY(), size=20, ctype='orange')   \n",
     "\n",
-    "    # Our \"ultra-faint galaxy\" (e.g. smudge)\n",
+    "    # Our low-surface-brightness \"galaxy\" (a.k.a. our \"smudge\")\n",
     "    afw_display.dot('o', x_target, y_target, size=35, ctype='cyan')"
    ]
   },
@@ -795,9 +799,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/SourceDetection/LowSurfaceBrightness.ipynb
+++ b/SourceDetection/LowSurfaceBrightness.ipynb
@@ -113,7 +113,7 @@
    "source": [
     "### Data access\n",
     "\n",
-    "Here we use the `butler` to access a `calexp` from the Twinkles data subset. More information on the `butler` will be available in `Butler_Tutorial.ipynb` (TBD), while a deeper examination of the `calexp` object can be found in [Calexp_guided_tour.ipynb](https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/Calexp_guided_tour.ipynb). We expect the user to have a working knowledge of these objects."
+    "Here we use the `butler` to access a `calexp` from a dataset in the RC repo. More information on the `butler` will be available in `Butler_Tutorial.ipynb` (TBD), while a deeper examination of the `calexp` object can be found in [Calexp_guided_tour.ipynb](https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/Calexp_guided_tour.ipynb). We expect the user to have a working knowledge of these objects."
    ]
   },
   {


### PR DESCRIPTION
Updating the LowSurfaceBrightness notebook to run on v20. Removed dependency on Twinkles data and replaced with the HSC RC data set (`/datasets/hsc/repo/rerun/RC/v20_0_0_rc1/DM-25349`). 

This is work towards issue #236.